### PR TITLE
Prepare 1.0.0 stable release

### DIFF
--- a/smolrouter/__init__.py
+++ b/smolrouter/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for SmolRouter."""
+
+__all__ = ["__version__"]
+__version__ = "1.0.0"


### PR DESCRIPTION
## Summary
- expose the package version via `smolrouter.__version__` for distribution metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb96951f788331bec1955863f42c13