### PR TITLE
Add embeddings support for Google and OpenAI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,9 @@
 - 🟡 Reassess body-archival lag after blob-storage hot-path fix
     The original O(N²) write-path issue has been addressed: `FilesystemBlobStorage` now uses a persisted usage counter instead of scanning the whole tree on every write, and request/response body archival stores are already offloaded via `asyncio.to_thread`. If operators still observe blank request/response bodies that appear later, the remaining work is to measure the current bottleneck accurately before changing storage again (for example: async eventual-consistency on detail views, write amplification from per-request files, or janitor contention). This is still relevant context for any future segment-store work, but the backlog item should no longer assume the old synchronous full-tree scan is the active bug. Files: `smolrouter/storage.py`, `smolrouter/database.py`. Context: `docs/PROPOSAL_segment_blob_storage.md`.
 
+- 🔴 OpenAI + Google `/v1/embeddings` endpoint support (in progress)
+    `POST /v1/embeddings` now exists on the shared OpenAI proxy path and works end-to-end against an OpenAI-compatible local upstream, with auth-path parity and body archival verified. Google GenAI embeddings support has also been wired through the provider stack and model discovery now includes `embedContent` models, but a live Google smoke is still pending because no Google API key is configured in this environment. Acceptance remains: prove both OpenAI-compatible and Google GenAI embeddings paths with smoke where credentials are available.
+
 - 🟡 Provider-key accounting convergence
     Google GenAI has comprehensive per-key token/request counting with quota tracking, and the Redis quota primitives already exist for reuse. The remaining gap is provider integration consistency: Anthropic currently reports model-level stats rather than true per-key accounting, and OpenAI-compatible flows still need explicit key-level usage tracking across configured-key and BYOK/passthrough modes. This should follow facade-key identity/accounting so downstream-secret observability complements, rather than substitutes for, project/use-case accounting. Files: `providers.py` (OpenAI path), `anthropic_provider.py`, `database.py`, `redis_backend.py`
 
@@ -32,7 +35,7 @@
 ## Low Priority
 
 - 🟠 Documentation Site + README Overhaul (TODO - unstarted, planning only)
-    Current README currently carries deep reference material (especially env vars, provider setup, and deployment details), making it harder for users to quickly understand what SmolRouter can do. Scope this work as two linked tasks:
+    README currently carries deep reference material (especially env vars, provider setup, and deployment details), making it harder for users to quickly understand what SmolRouter can do. Scope this work as two linked tasks:
     1) Establish a dedicated docs site so canonical reference can move out of README.
     2) Rework README into a faster, visual landing experience with examples and screenshots.
 
@@ -50,9 +53,8 @@
     - a visual section (screenshots, GIF loop, or slide-like step gallery) showing request routing, dashboard visibility, and quota/accounting behavior.
     Keep the full env/config reference in the docs site and add strict deep links from README.
 
-- 🔵 Move from Static Pages to Dynamic API
-    Current dashboard uses server-side rendered HTML templates. Move to SPA (Single Page App) with separate API endpoints. Benefits: Better UX, real-time updates, easier testing. Templates to migrate: `templates/index.html`, `templates/system.html`, etc. New endpoints needed: `/api/dashboard`, `/api/providers`, `/api/stats`
-    Current dashboard uses server-side rendered templates with API-backed data fetching. Most main pages are API-driven but render via Jinja templates (`templates/index.html`, `providers.html`, `performance.html`). Core dashboard data endpoints exist (`/api/dashboard`, `/api/stats`), and provider list data is currently exposed via `/api/upstreams` (not `/api/providers`).
+- 🔵 Move from server-rendered dashboard pages to richer client/API UI
+    Existing dashboard pages are server-rendered via Jinja templates with API-backed data sources. If a future SPA migration proceeds, target `/api/dashboard`, `/api/providers`, and `/api/stats` alongside `templates/index.html`, `templates/system.html`, and related views. Core dashboard endpoints already exist (`/api/dashboard`, `/api/stats`), while provider list data is currently exposed via `/api/upstreams` (not `/api/providers`).
 
 - 🔵 Improve JSON formatting + raw copy for request/body views (TODO - unstarted)
     Request and response payload blocks in web detail views should be consistently pretty-printed with a dedicated raw-copy action, including request and body payloads.

--- a/smolrouter/app.py
+++ b/smolrouter/app.py
@@ -2722,7 +2722,7 @@ def _body_status(log_entry: Any, body_name: str) -> str:
         return str(status)
 
     body = getattr(log_entry, body_name, None)
-    if body is not None:
+    if body:
         return "available"
 
     if getattr(log_entry, f"{body_name}_key", None):

--- a/smolrouter/app.py
+++ b/smolrouter/app.py
@@ -2258,6 +2258,11 @@ async def responses(request: Request):
     return await proxy_request("/v1/responses", request)
 
 
+@app.post("/v1/embeddings", responses=OPENAI_PROXY_ROUTE_RESPONSES)
+async def embeddings(request: Request):
+    return await proxy_request("/v1/embeddings", request)
+
+
 @app.get("/v1/models")
 async def list_models(request: Request):
     """List available models with aggregation from multiple providers"""
@@ -2711,6 +2716,21 @@ def _decode_log_body(body: Any) -> Optional[str]:
     return str(body)
 
 
+def _body_status(log_entry: Any, body_name: str) -> str:
+    status = getattr(log_entry, f"{body_name}_status", None)
+    if status in {"available", "not_stored", "not_found", "storage_error"}:
+        return str(status)
+
+    body = getattr(log_entry, body_name, None)
+    if body is not None:
+        return "available"
+
+    if getattr(log_entry, f"{body_name}_key", None):
+        return "not_found"
+
+    return "not_stored"
+
+
 def _serialize_duplicate_request_log(log_entry: Any) -> dict[str, Any]:
     timestamp = getattr(log_entry, "timestamp", None)
     return {
@@ -2754,6 +2774,8 @@ def _serialize_request_detail_response(log_entry: Any, duplicate_info: dict[str,
         **{field_name: summary[field_name] for field_name in REQUEST_DETAIL_RESPONSE_FIELDS},
         "request_body": _decode_log_body(getattr(log_entry, "request_body", None)),
         "response_body": _decode_log_body(getattr(log_entry, "response_body", None)),
+        "request_body_status": _body_status(log_entry, "request_body"),
+        "response_body_status": _body_status(log_entry, "response_body"),
         "duplicate": duplicate_info,
     }
 
@@ -3749,6 +3771,8 @@ async def request_detail(request_id: str, request: Request):
                 "response_body_str": getattr(log_entry, "response_body", b"").decode("utf-8")
                 if getattr(log_entry, "response_body", None)
                 else None,
+                "request_body_status": _body_status(log_entry, "request_body"),
+                "response_body_status": _body_status(log_entry, "response_body"),
                 "duplicates": duplicates,
             },
         )

--- a/smolrouter/auth.py
+++ b/smolrouter/auth.py
@@ -187,6 +187,7 @@ def create_auth_middleware():
                 "/v1/chat/completions",
                 "/v1/completions",
                 "/v1/responses",
+                "/v1/embeddings",
             }
 
         async def dispatch(self, request: Request, call_next):

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -13,6 +13,7 @@ import io
 import re
 import secrets
 import wave
+from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass, field
@@ -2390,17 +2391,53 @@ class GoogleGenAIProvider(IModelProvider):
         await self._rate_limiter.acquire_slot()
         try:
             if context.request_kind == "embed_content":
-                token_counts = await asyncio.to_thread(
-                    context.client.models.count_tokens,
-                    model=context.model_name,
-                    contents=context.genai_request["contents"],
-                )
-                context.input_token_count = getattr(token_counts, "total_tokens", None)
-                return await asyncio.to_thread(
-                    context.client.models.embed_content,
-                    model=context.model_name,
-                    contents=context.genai_request["contents"],
-                    config=context.genai_request.get("config"),
+                contents = context.genai_request["contents"]
+                embed_inputs = contents if isinstance(contents, list) else [contents]
+                embedding_responses = []
+                token_total = 0
+
+                for embed_input in embed_inputs:
+                    try:
+                        token_counts = await asyncio.to_thread(
+                            context.client.models.count_tokens,
+                            model=context.model_name,
+                            contents=embed_input,
+                        )
+                        token_total += int(getattr(token_counts, "total_tokens", 0) or 0)
+                    except Exception:
+                        logger.debug(
+                            "Embedding token preflight failed for %s",
+                            context.model_name,
+                            exc_info=True,
+                        )
+
+                    embedding_responses.append(
+                        await asyncio.to_thread(
+                            context.client.models.embed_content,
+                            model=context.model_name,
+                            contents=embed_input,
+                            config=context.genai_request.get("config"),
+                        )
+                    )
+
+                context.input_token_count = token_total or None
+                if len(embedding_responses) == 1:
+                    return embedding_responses[0]
+
+                combined_embeddings = []
+                combined_billable_chars = 0
+                for embedding_response in embedding_responses:
+                    response_embeddings = getattr(embedding_response, "embeddings", None)
+                    if not response_embeddings:
+                        single_embedding = getattr(embedding_response, "embedding", None)
+                        response_embeddings = [single_embedding] if single_embedding else []
+                    combined_embeddings.extend(response_embeddings)
+                    metadata = getattr(embedding_response, "metadata", None)
+                    combined_billable_chars += int(getattr(metadata, "billable_character_count", 0) or 0)
+
+                return SimpleNamespace(
+                    embeddings=combined_embeddings,
+                    metadata=SimpleNamespace(billable_character_count=combined_billable_chars or token_total),
                 )
 
             return await asyncio.to_thread(
@@ -2525,7 +2562,13 @@ class GoogleGenAIProvider(IModelProvider):
         original_model: str,
         token_count: Optional[int] = None,
     ) -> Dict[str, Any]:
-        embeddings = getattr(genai_response, "embeddings", None) or []
+        embeddings = getattr(genai_response, "embeddings", None)
+        if not embeddings:
+            single_embedding = getattr(genai_response, "embedding", None)
+            embeddings = [single_embedding] if single_embedding else []
+        elif not isinstance(embeddings, list):
+            embeddings = [embeddings]
+
         data = []
         for index, embedding in enumerate(embeddings):
             data.append(

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -39,6 +39,7 @@ PACIFIC_TZ = ZoneInfo("America/Los_Angeles")
 OPENAI_CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
 OPENAI_COMPLETIONS_ENDPOINT = "/v1/completions"
 OPENAI_RESPONSES_ENDPOINT = "/v1/responses"
+OPENAI_EMBEDDINGS_ENDPOINT = "/v1/embeddings"
 GOOGLE_GENAI_STATIC_MODELS_SNAPSHOT = "google-genai-models-2026-july.json"
 AUDIO_WAV_MIME_TYPE = "audio/wav"
 AUDIO_PCM_MIME_TYPE = "audio/pcm"
@@ -228,10 +229,12 @@ class GoogleGenAICompletionContext:
     original_model: str
     observation_id: str
     endpoint: str = OPENAI_CHAT_COMPLETIONS_ENDPOINT
+    request_kind: str = "generate_content"
     model_name: str = ""
     tts_request: bool = False
     tts_audio_format: str = "pcm"
     genai_request: Dict[str, Any] = field(default_factory=dict)
+    input_token_count: Optional[int] = None
     api_key: str = ""
     api_key_suffix: Optional[str] = None
     api_key_index: Optional[int] = None
@@ -1382,6 +1385,7 @@ class GoogleGenAIProvider(IModelProvider):
             "display_name": getattr(model, "display_name", model_name),
             "description": getattr(model, "description", ""),
             "supported_methods": supported_actions,
+            "supports_embeddings": "embedContent" in supported_actions,
             "input_token_limit": getattr(model, "input_token_limit", None),
             "output_token_limit": getattr(model, "output_token_limit", None),
         }
@@ -1394,6 +1398,7 @@ class GoogleGenAIProvider(IModelProvider):
             "display_name": model_data.get("displayName", model_name),
             "description": model_data.get("description", ""),
             "supported_methods": supported_methods,
+            "supports_embeddings": "embedContent" in supported_methods,
             "input_token_limit": model_data.get("inputTokenLimit"),
             "output_token_limit": model_data.get("outputTokenLimit"),
             "version": model_data.get("version"),
@@ -1478,15 +1483,17 @@ class GoogleGenAIProvider(IModelProvider):
         for model in model_list:
             # New API uses 'supported_actions' instead of 'supported_generation_methods'
             supported_actions = getattr(model, "supported_actions", [])
-            if "generateContent" in supported_actions:
-                model_name = self._extract_google_model_name(getattr(model, "name", "") or "")
+            if not self._is_google_supported_action_model(supported_actions):
+                continue
 
-                model_info = self._build_google_model_info(
-                    model_name,
-                    self._build_live_google_model_metadata(model, supported_actions),
-                )
-                models.append(model_info)
-                logger.debug(f"Discovered Google GenAI model: {model_info.id}")
+            model_name = self._extract_google_model_name(getattr(model, "name", "") or "")
+
+            model_info = self._build_google_model_info(
+                model_name,
+                self._build_live_google_model_metadata(model, supported_actions),
+            )
+            models.append(model_info)
+            logger.debug(f"Discovered Google GenAI model: {model_info.id}")
 
         return models
 
@@ -1544,10 +1551,9 @@ class GoogleGenAIProvider(IModelProvider):
 
             models = []
             for model_data in data.get("models", []):
-                # Only include models that support text generation
                 supported_methods = model_data.get("supportedGenerationMethods") or model_data.get("supportedActions", [])
-                if "generateContent" not in supported_methods:
-                    continue  # Skip embedding and other non-text generation models
+                if not self._is_google_supported_action_model(supported_methods):
+                    continue
 
                 model_name = self._extract_google_model_name(model_data.get("name", ""))
                 model_info = self._build_google_model_info(
@@ -1570,6 +1576,26 @@ class GoogleGenAIProvider(IModelProvider):
         endpoint: str = OPENAI_CHAT_COMPLETIONS_ENDPOINT,
     ) -> Tuple[str, Dict[str, Any]]:
         """Convert OpenAI request format to Google GenAI format"""
+        if endpoint == OPENAI_EMBEDDINGS_ENDPOINT:
+            model_name = self._normalize_model_name(openai_request.get("model", ""))
+            contents = openai_request.get("input")
+            if contents is None:
+                raise ValueError("No input provided in request")
+
+            embed_config: Dict[str, Any] = {}
+            if openai_request.get("dimensions") is not None:
+                embed_config["output_dimensionality"] = openai_request["dimensions"]
+            if openai_request.get("task_type") is not None:
+                embed_config["task_type"] = openai_request["task_type"]
+            if openai_request.get("title") is not None:
+                embed_config["title"] = openai_request["title"]
+            if openai_request.get("mime_type") is not None:
+                embed_config["mime_type"] = openai_request["mime_type"]
+            if openai_request.get("auto_truncate") is not None:
+                embed_config["auto_truncate"] = openai_request["auto_truncate"]
+
+            return model_name, {"contents": contents, "config": embed_config or None}
+
         request_payload = (
             self._convert_openai_responses_to_chat_request(openai_request)
             if endpoint == OPENAI_RESPONSES_ENDPOINT
@@ -2276,6 +2302,7 @@ class GoogleGenAIProvider(IModelProvider):
             original_model=openai_request.get("model", ""),
             observation_id=f"obs_{uuid.uuid4().hex[:12]}",
             endpoint=endpoint,
+            request_kind="embed_content" if endpoint == OPENAI_EMBEDDINGS_ENDPOINT else "generate_content",
         )
 
         try:
@@ -2362,6 +2389,20 @@ class GoogleGenAIProvider(IModelProvider):
     async def _run_completion_request(self, context: GoogleGenAICompletionContext) -> Any:
         await self._rate_limiter.acquire_slot()
         try:
+            if context.request_kind == "embed_content":
+                token_counts = await asyncio.to_thread(
+                    context.client.models.count_tokens,
+                    model=context.model_name,
+                    contents=context.genai_request["contents"],
+                )
+                context.input_token_count = getattr(token_counts, "total_tokens", None)
+                return await asyncio.to_thread(
+                    context.client.models.embed_content,
+                    model=context.model_name,
+                    contents=context.genai_request["contents"],
+                    config=context.genai_request.get("config"),
+                )
+
             return await asyncio.to_thread(
                 context.client.models.generate_content,
                 model=context.model_name,
@@ -2377,6 +2418,12 @@ class GoogleGenAIProvider(IModelProvider):
         endpoint: str,
         context: GoogleGenAICompletionContext,
     ) -> None:
+        if endpoint == OPENAI_EMBEDDINGS_ENDPOINT and openai_request.get("input") is None:
+            raise self._build_request_error_from_context(
+                context,
+                "400 invalid argument: embeddings requests require an input",
+            )
+
         if self._is_tts_request(openai_request):
             try:
                 self._validate_tts_request(openai_request, endpoint)
@@ -2395,6 +2442,39 @@ class GoogleGenAIProvider(IModelProvider):
     ) -> tuple[Dict[str, Any], Optional["RequestMetadata"]]:
         from .request_metadata import RequestMetadata
         from .transport_observer import get_observer
+
+        if context.request_kind == "embed_content":
+            openai_response = self._convert_genai_to_embeddings_response(
+                response,
+                context.original_model,
+                context.input_token_count,
+            )
+
+            tokens_used = openai_response.get("usage", {}).get("total_tokens", 0)
+            await self._update_api_key_stats(context.api_key, context.model_name, success=True, tokens=tokens_used)
+
+            if context.proxy_url:
+                self._mark_proxy_health(context.proxy_url, success=True)
+
+            observer = get_observer()
+            observation = observer.get_observation(context.observation_id)
+            actual_key_suffix, actual_proxy, key_verified, proxy_verified = self._resolve_observation_state(
+                context, observation
+            )
+
+            metadata = RequestMetadata(
+                api_key_suffix=actual_key_suffix,
+                proxy_used=actual_proxy,
+                provider_id=self.config.name,
+                model_name=context.model_name,
+                api_key_index=context.api_key_index if context.api_key_index else None,
+                api_key_total=context.api_key_total if context.api_key_total else None,
+                api_key_verified=key_verified,
+                proxy_verified=proxy_verified,
+                observation_id=context.observation_id,
+            )
+
+            return openai_response, metadata
 
         if context.tts_request and context.endpoint == OPENAI_RESPONSES_ENDPOINT:
             openai_response = self._convert_genai_to_responses_audio_response(
@@ -2434,6 +2514,43 @@ class GoogleGenAIProvider(IModelProvider):
         )
 
         return openai_response, metadata
+
+    @staticmethod
+    def _is_google_supported_action_model(supported_actions: List[str]) -> bool:
+        return "generateContent" in supported_actions or "embedContent" in supported_actions
+
+    def _convert_genai_to_embeddings_response(
+        self,
+        genai_response: Any,
+        original_model: str,
+        token_count: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        embeddings = getattr(genai_response, "embeddings", None) or []
+        data = []
+        for index, embedding in enumerate(embeddings):
+            data.append(
+                {
+                    "object": "embedding",
+                    "index": index,
+                    "embedding": list(getattr(embedding, "values", None) or []),
+                }
+            )
+
+        usage_tokens = token_count
+        if usage_tokens is None:
+            metadata = getattr(genai_response, "metadata", None)
+            usage_tokens = getattr(metadata, "billable_character_count", None)
+
+        usage_tokens = int(usage_tokens or 0)
+        return {
+            "object": "list",
+            "data": data,
+            "model": original_model,
+            "usage": {
+                "prompt_tokens": usage_tokens,
+                "total_tokens": usage_tokens,
+            },
+        }
 
     def _resolve_observation_state(
         self, context: GoogleGenAICompletionContext, observation: Any

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -33,6 +33,7 @@ from .redis_backend import QuotaRecord
 from .rate_limiter import GoogleGenAIRequestFunnel
 from .request_metadata import RequestMetadata
 from .task_utils import create_logged_task
+from .transport_observer import get_observer
 
 logger = logging.getLogger(__name__)
 
@@ -2474,44 +2475,43 @@ class GoogleGenAIProvider(IModelProvider):
                 "in the Google GenAI compatibility shim",
             )
 
+    async def _build_completion_metadata(
+        self, context: GoogleGenAICompletionContext, tokens_used: int
+    ) -> RequestMetadata:
+        await self._update_api_key_stats(context.api_key, context.model_name, success=True, tokens=tokens_used)
+
+        if context.proxy_url:
+            self._mark_proxy_health(context.proxy_url, success=True)
+
+        observer = get_observer()
+        observation = observer.get_observation(context.observation_id)
+        actual_key_suffix, actual_proxy, key_verified, proxy_verified = self._resolve_observation_state(
+            context, observation
+        )
+
+        return RequestMetadata(
+            api_key_suffix=actual_key_suffix,
+            proxy_used=actual_proxy,
+            provider_id=self.config.name,
+            model_name=context.model_name,
+            api_key_index=context.api_key_index if context.api_key_index else None,
+            api_key_total=context.api_key_total if context.api_key_total else None,
+            api_key_verified=key_verified,
+            proxy_verified=proxy_verified,
+            observation_id=context.observation_id,
+        )
+
     async def _finalize_completion(
         self, context: GoogleGenAICompletionContext, response: Any
     ) -> tuple[Dict[str, Any], Optional["RequestMetadata"]]:
-        from .request_metadata import RequestMetadata
-        from .transport_observer import get_observer
-
         if context.request_kind == "embed_content":
             openai_response = self._convert_genai_to_embeddings_response(
                 response,
                 context.original_model,
                 context.input_token_count,
             )
-
             tokens_used = openai_response.get("usage", {}).get("total_tokens", 0)
-            await self._update_api_key_stats(context.api_key, context.model_name, success=True, tokens=tokens_used)
-
-            if context.proxy_url:
-                self._mark_proxy_health(context.proxy_url, success=True)
-
-            observer = get_observer()
-            observation = observer.get_observation(context.observation_id)
-            actual_key_suffix, actual_proxy, key_verified, proxy_verified = self._resolve_observation_state(
-                context, observation
-            )
-
-            metadata = RequestMetadata(
-                api_key_suffix=actual_key_suffix,
-                proxy_used=actual_proxy,
-                provider_id=self.config.name,
-                model_name=context.model_name,
-                api_key_index=context.api_key_index if context.api_key_index else None,
-                api_key_total=context.api_key_total if context.api_key_total else None,
-                api_key_verified=key_verified,
-                proxy_verified=proxy_verified,
-                observation_id=context.observation_id,
-            )
-
-            return openai_response, metadata
+            return openai_response, await self._build_completion_metadata(context, tokens_used)
 
         if context.tts_request and context.endpoint == OPENAI_RESPONSES_ENDPOINT:
             openai_response = self._convert_genai_to_responses_audio_response(
@@ -2527,30 +2527,7 @@ class GoogleGenAIProvider(IModelProvider):
             openai_response = self._convert_genai_to_openai_response(response, context.original_model)
 
         tokens_used = openai_response.get("usage", {}).get("total_tokens", 0)
-        await self._update_api_key_stats(context.api_key, context.model_name, success=True, tokens=tokens_used)
-
-        if context.proxy_url:
-            self._mark_proxy_health(context.proxy_url, success=True)
-
-        observer = get_observer()
-        observation = observer.get_observation(context.observation_id)
-        actual_key_suffix, actual_proxy, key_verified, proxy_verified = self._resolve_observation_state(
-            context, observation
-        )
-
-        metadata = RequestMetadata(
-            api_key_suffix=actual_key_suffix,
-            proxy_used=actual_proxy,
-            provider_id=self.config.name,
-            model_name=context.model_name,
-            api_key_index=context.api_key_index if context.api_key_index else None,
-            api_key_total=context.api_key_total if context.api_key_total else None,
-            api_key_verified=key_verified,
-            proxy_verified=proxy_verified,
-            observation_id=context.observation_id,
-        )
-
-        return openai_response, metadata
+        return openai_response, await self._build_completion_metadata(context, tokens_used)
 
     @staticmethod
     def _is_google_supported_action_model(supported_actions: List[str]) -> bool:

--- a/smolrouter/providers.py
+++ b/smolrouter/providers.py
@@ -243,6 +243,7 @@ class OpenAIProvider(BaseModelProvider):
 
                 data = response.json()
                 models = []
+                seen_model_names = set()
 
                 for model_data in data.get("data", []):
                     model_id = model_data.get("id", "unknown")
@@ -258,7 +259,19 @@ class OpenAIProvider(BaseModelProvider):
                     model_info = self._create_openai_model_info(model_id, metadata=metadata)
 
                     models.append(model_info)
+                    seen_model_names.add(model_info.name)
                     logger.debug(f"Discovered OpenAI model: {model_info.id}")
+
+                if self._should_include_static_openai_embedding_models():
+                    for model_info in self._get_static_openai_models():
+                        if not model_info.name.startswith("text-embedding-"):
+                            continue
+                        if model_info.name in seen_model_names:
+                            continue
+
+                        models.append(model_info)
+                        seen_model_names.add(model_info.name)
+                        logger.debug("Backfilled OpenAI embedding model: %s", model_info.id)
 
                 logger.info(f"Discovered {len(models)} models from OpenAI provider {self.get_provider_id()}")
                 return models

--- a/smolrouter/providers.py
+++ b/smolrouter/providers.py
@@ -360,6 +360,10 @@ class OpenAIProvider(BaseModelProvider):
         logger.info(f"Providing {len(models)} fallback OpenAI models for {self.get_provider_id()}")
         return models
 
+    def _should_include_static_openai_embedding_models(self) -> bool:
+        parsed_url = urlsplit(self.config.url.rstrip("/"))
+        return parsed_url.scheme == "https" and parsed_url.netloc == "api.openai.com"
+
     @staticmethod
     def _normalize_client_header_value(value: Any) -> Any:
         return value.decode("utf-8") if isinstance(value, bytes) else value

--- a/smolrouter/redis_backend.py
+++ b/smolrouter/redis_backend.py
@@ -206,6 +206,9 @@ def _load_blob_body(blob_storage: Any, key: Any) -> tuple[Any, str]:
     if not key:
         return None, "not_stored"
 
+    if not blob_storage:
+        return None, "storage_error"
+
     try:
         data = blob_storage.retrieve(key)
     except Exception:

--- a/smolrouter/redis_backend.py
+++ b/smolrouter/redis_backend.py
@@ -202,10 +202,20 @@ def _normalize_datetime(value: Any) -> Optional[datetime]:
     return normalized
 
 
-def _load_blob_body(blob_storage: Any, key: Any) -> Any:
+def _load_blob_body(blob_storage: Any, key: Any) -> tuple[Any, str]:
     if not key:
-        return None
-    return blob_storage.retrieve(key)
+        return None, "not_stored"
+
+    try:
+        data = blob_storage.retrieve(key)
+    except Exception:
+        logger.exception("Failed to retrieve blob %s", key)
+        return None, "storage_error"
+
+    if data is None:
+        return None, "not_found"
+
+    return data, "available"
 
 
 def _prepare_quota_record_data(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -467,8 +477,12 @@ class LogRecord:
         from .storage import get_blob_storage
 
         blob_storage = get_blob_storage()
-        self.request_body = _load_blob_body(blob_storage, getattr(self, "request_body_key", None))
-        self.response_body = _load_blob_body(blob_storage, getattr(self, "response_body_key", None))
+        self.request_body, self.request_body_status = _load_blob_body(
+            blob_storage, getattr(self, "request_body_key", None)
+        )
+        self.response_body, self.response_body_status = _load_blob_body(
+            blob_storage, getattr(self, "response_body_key", None)
+        )
 
     def items(self):
         """Provide dict-like items() method for backward compatibility"""

--- a/smolrouter/templates/request_detail.html
+++ b/smolrouter/templates/request_detail.html
@@ -449,8 +449,6 @@
                         Unable to retrieve request body (storage error)
                         {% elif request_body_status == "not_found" %}
                         Unable to retrieve request body (missing blob)
-                        {% elif request_body_status == "not_stored" %}
-                        Not stored
                         {% else %}
                         Request body unavailable
                         {% endif %}
@@ -505,8 +503,6 @@
                         Unable to retrieve response body (storage error)
                         {% elif response_body_status == "not_found" %}
                         Unable to retrieve response body (missing blob)
-                        {% elif response_body_status == "not_stored" %}
-                        Not stored
                         {% else %}
                         Response body unavailable
                         {% endif %}

--- a/smolrouter/templates/request_detail.html
+++ b/smolrouter/templates/request_detail.html
@@ -440,6 +440,23 @@
                     <div class="code-block">{{ request_body_str }}</div>
                 </div>
             </div>
+            {% elif request_body_status and request_body_status != "not_stored" %}
+            <div class="detail-section">
+                <div class="detail-row">
+                    <span class="detail-label">Request Body</span>
+                    <span class="detail-value">
+                        {% if request_body_status == "storage_error" %}
+                        Unable to retrieve request body (storage error)
+                        {% elif request_body_status == "not_found" %}
+                        Unable to retrieve request body (missing blob)
+                        {% elif request_body_status == "not_stored" %}
+                        Not stored
+                        {% else %}
+                        Request body unavailable
+                        {% endif %}
+                    </span>
+                </div>
+            </div>
             {% endif %}
 
             <!-- Duplicate Requests -->
@@ -477,6 +494,23 @@
                 </button>
                 <div class="collapsible-content">
                     <div class="code-block">{{ response_body_str }}</div>
+                </div>
+            </div>
+            {% elif response_body_status and response_body_status != "not_stored" %}
+            <div class="detail-section">
+                <div class="detail-row">
+                    <span class="detail-label">Response Body</span>
+                    <span class="detail-value">
+                        {% if response_body_status == "storage_error" %}
+                        Unable to retrieve response body (storage error)
+                        {% elif response_body_status == "not_found" %}
+                        Unable to retrieve response body (missing blob)
+                        {% elif response_body_status == "not_stored" %}
+                        Not stored
+                        {% else %}
+                        Response body unavailable
+                        {% endif %}
+                    </span>
                 </div>
             </div>
             {% endif %}

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -2194,6 +2194,12 @@ def test_serialize_request_log_normalizes_empty_provider_id():
     assert payload["provider_id"] is None
 
 
+def test_body_status_treats_empty_payload_as_not_found():
+    log_entry = SimpleNamespace(request_body=b"", request_body_key="req-body")
+
+    assert app_module._body_status(log_entry, "request_body") == "not_found"
+
+
 def test_serialize_request_detail_response_reuses_summary_and_provider_metadata():
     timestamp = app_module.datetime.now()
     log_entry = SimpleNamespace(

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -53,6 +53,19 @@ def mock_openai_upstream():
         respx_mock.post("http://localhost:8000/v1/completions").mock(
             return_value=httpx.Response(200, json=load_mock_json("openai_completion_non_streaming.json"))
         )
+        respx_mock.post("http://localhost:8000/v1/embeddings").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]},
+                    ],
+                    "model": "text-embedding-3-small",
+                    "usage": {"prompt_tokens": 1, "total_tokens": 1},
+                },
+            )
+        )
         respx_mock.get("http://localhost:8000/v1/models").mock(
             return_value=httpx.Response(200, json=load_mock_json("openai_list_models.json"))
         )
@@ -97,6 +110,21 @@ async def test_openai_completions_non_streaming(async_client, mock_openai_upstre
 
 
 @pytest.mark.asyncio
+async def test_openai_embeddings_non_streaming(async_client, mock_openai_upstream, disable_logging):
+    response = await async_client.post(
+        "/v1/embeddings",
+        json={"model": "text-embedding-3-small", "input": "Hello embeddings"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "list"
+    assert data["data"][0]["object"] == "embedding"
+    assert data["data"][0]["index"] == 0
+    assert data["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
 async def test_openai_invalid_json_returns_400(async_client, disable_logging):
     response = await async_client.post(
         "/v1/chat/completions",
@@ -128,6 +156,28 @@ async def test_openai_streaming_falls_back_to_non_streaming_provider_architectur
     assert response.json()["choices"][0]["message"]["content"] == "fallback response"
     fake_container.route_streaming_request.assert_awaited_once()
     fake_container.route_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_openai_embeddings_route_is_exposed_and_uses_shared_proxy(async_client, disable_logging, monkeypatch):
+    captured = {}
+
+    async def fake_proxy_request(path, request):
+        captured["path"] = path
+        captured["body"] = await request.json()
+        return {"object": "list", "data": []}
+
+    monkeypatch.setattr(app_module, "proxy_request", fake_proxy_request)
+
+    response = await async_client.post(
+        "/v1/embeddings",
+        json={"model": "text-embedding-3-small", "input": ["hello", "world"]},
+    )
+
+    assert response.status_code == 200
+    assert captured["path"] == "/v1/embeddings"
+    assert captured["body"]["model"] == "text-embedding-3-small"
+    assert captured["body"]["input"] == ["hello", "world"]
 
 
 @pytest.mark.asyncio
@@ -1392,6 +1442,11 @@ def test_openapi_documents_proxy_and_project_api_error_responses():
     assert chat_responses["400"]["description"] == "Invalid request payload"
     assert chat_responses["401"]["description"] == "Invalid or mismatched local facade key"
     assert chat_responses["503"]["description"] == "Routing unavailable"
+    assert "/v1/embeddings" in schema["paths"]
+    embeddings_responses = schema["paths"]["/v1/embeddings"]["post"]["responses"]
+    assert embeddings_responses["400"]["description"] == "Invalid request payload"
+    assert embeddings_responses["401"]["description"] == "Invalid or mismatched local facade key"
+    assert embeddings_responses["503"]["description"] == "Routing unavailable"
 
     projects_responses = schema["paths"]["/api/projects"]["get"]["responses"]
     assert projects_responses["500"]["description"] == "Failed to load project inventory"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -224,6 +224,14 @@ async def test_middleware_allows_openai_write_routes_without_jwt(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_middleware_allows_embeddings_write_route_without_jwt(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", STRONG_SECRET)
+    mw = _build_middleware()
+    result = await mw.dispatch(_MiddlewareRequest("/v1/embeddings", method="POST"), _call_next_sentinel)
+    assert result == "passed-through"
+
+
+@pytest.mark.asyncio
 async def test_middleware_does_not_bypass_get_on_openai_write_route(monkeypatch):
     monkeypatch.setenv("JWT_SECRET", STRONG_SECRET)
     mw = _build_middleware()

--- a/tests/unit/test_google_genai_helpers.py
+++ b/tests/unit/test_google_genai_helpers.py
@@ -199,6 +199,20 @@ def test_convert_openai_to_genai_request_accepts_responses_string_input(provider
     assert genai_request["generation_config"]["max_output_tokens"] == 77
 
 
+def test_convert_openai_to_genai_request_accepts_embeddings_input(provider):
+    request = {
+        "model": "gemini-embedding-001",
+        "input": ["hello", "world"],
+        "dimensions": 768,
+    }
+
+    model_name, genai_request = provider._convert_openai_to_genai_request(request, endpoint="/v1/embeddings")
+
+    assert model_name == "gemini-embedding-001"
+    assert genai_request["contents"] == ["hello", "world"]
+    assert genai_request["config"]["output_dimensionality"] == 768
+
+
 def test_convert_openai_to_genai_request_accepts_responses_multimodal_input(provider):
     request = {
         "model": "gemini-2.5-flash",

--- a/tests/unit/test_new_integrations.py
+++ b/tests/unit/test_new_integrations.py
@@ -308,12 +308,12 @@ async def test_google_genai_discover_models_uses_cache_and_filters_supported_act
             output_token_limit=1024,
         ),
         SimpleNamespace(
-            name="models/text-embedding",
+            name="models/gemini-embedding-001",
             display_name="Embed",
-            description="Nope",
+            description="Vectors",
             supported_actions=["embedContent"],
             input_token_limit=2048,
-            output_token_limit=0,
+            output_token_limit=3072,
         ),
     ]
 
@@ -329,10 +329,12 @@ async def test_google_genai_discover_models_uses_cache_and_filters_supported_act
 
     assert client_factory.call_count == 1
     assert cached_models is models
-    assert len(models) == 1
+    assert len(models) == 2
     assert models[0].name == "gemini-2.0-flash"
     assert models[0].metadata["display_name"] == "Gemini Flash"
     assert models[0].metadata["input_token_limit"] == 8192
+    assert models[1].name == "gemini-embedding-001"
+    assert models[1].metadata["supports_embeddings"] is True
 
 
 @pytest.mark.asyncio
@@ -362,10 +364,12 @@ async def test_google_genai_discover_models_falls_back_to_static_json():
                             "thinking": True,
                         },
                         {
-                            "name": "models/gemini-embedding",
+                            "name": "models/gemini-embedding-001",
                             "displayName": "Embed",
-                            "description": "Skip me",
+                            "description": "Keep me",
                             "supportedActions": ["embedContent"],
+                            "inputTokenLimit": 2048,
+                            "outputTokenLimit": 3072,
                         },
                     ]
                 }
@@ -374,10 +378,12 @@ async def test_google_genai_discover_models_falls_back_to_static_json():
     ):
         models = await provider.discover_models()
 
-    assert len(models) == 1
+    assert len(models) == 2
     assert models[0].name == "gemini-2.5-flash"
     assert models[0].metadata["thinking"] is True
     assert models[0].metadata["version"] == "v1"
+    assert models[1].name == "gemini-embedding-001"
+    assert models[1].metadata["supports_embeddings"] is True
 
 
 @pytest.mark.asyncio
@@ -443,6 +449,50 @@ async def test_google_genai_generate_completion_accepts_responses_endpoint():
     assert isinstance(build_args[1], GoogleGenAICompletionContext)
     assert build_args[1].original_model == "gemini-2.0-flash"
     assert build_args[2] == "/v1/responses"
+
+
+@pytest.mark.asyncio
+async def test_google_genai_generate_completion_accepts_embeddings_endpoint():
+    provider = _make_google_provider()
+    context = GoogleGenAICompletionContext(
+        original_model="original",
+        observation_id="obs-123",
+        endpoint="/v1/embeddings",
+        request_kind="embed_content",
+        model_name="gemini-embedding-001",
+        api_key="test-key",
+        api_key_suffix="abcd1234",
+        input_token_count=7,
+    )
+
+    provider._build_completion_context = AsyncMock(return_value=context)
+    provider._run_completion_request = AsyncMock(
+        return_value=SimpleNamespace(
+            embeddings=[SimpleNamespace(values=[0.1, 0.2, 0.3])],
+            metadata=SimpleNamespace(billable_character_count=7),
+        )
+    )
+    provider._update_api_key_stats = AsyncMock()
+
+    response = await provider.generate_completion(
+        {"model": "gemini-embedding-001", "input": "Hi"},
+        endpoint="/v1/embeddings",
+    )
+
+    response_data, metadata = response
+    assert response_data["object"] == "list"
+    assert response_data["data"][0]["object"] == "embedding"
+    assert response_data["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+    assert response_data["usage"]["total_tokens"] == 7
+    assert metadata is not None
+    assert metadata.provider_id == "test-google"
+    assert metadata.model_name == "gemini-embedding-001"
+    provider._build_completion_context.assert_awaited_once()
+    build_args = provider._build_completion_context.await_args.args
+    assert build_args[0] == {"model": "gemini-embedding-001", "input": "Hi"}
+    assert isinstance(build_args[1], GoogleGenAICompletionContext)
+    assert build_args[1].original_model == "gemini-embedding-001"
+    assert build_args[2] == "/v1/embeddings"
 
 
 @pytest.mark.asyncio
@@ -1955,6 +2005,49 @@ async def test_mediator_passes_responses_path_to_google_provider():
     provider.generate_completion.assert_awaited_once_with(
         {"model": "gemini-2.0-flash", "input": "Hello from responses"},
         "/v1/responses",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mediator_passes_embeddings_path_to_google_provider():
+    aggregator = Mock()
+    aggregator.get_all_models = AsyncMock(return_value=[])
+    mediator = ModelMediator(aggregator, SimpleModelStrategy({}), NoAccessControl())
+    resolved_model = ModelInfo(
+        id="gemini-embedding-001@test-google",
+        name="gemini-embedding-001",
+        provider_id="test-google",
+        provider_type="google-genai",
+        endpoint="https://generativelanguage.googleapis.com",
+    )
+    provider = _make_google_provider()
+    provider.generate_completion = AsyncMock(
+        return_value=(
+            {"object": "list", "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]}]},
+            RequestMetadata(provider_id="test-google", model_name="gemini-embedding-001"),
+        )
+    )
+    mediator.resolve_model_for_request = AsyncMock(return_value=resolved_model)
+    mediator._get_provider_by_id = Mock(return_value=provider)
+
+    response_data, status_code, upstream_used, metadata = await mediator.route_request(
+        "127.0.0.1",
+        "gemini-embedding-001 [test-google]",
+        {"model": "gemini-embedding-001 [test-google]", "input": "Hello embeddings"},
+        "/v1/embeddings",
+        {"authorization": "Bearer client-token"},
+        30.0,
+    )
+
+    assert status_code == 200
+    assert response_data["object"] == "list"
+    assert upstream_used == "google-genai:test-google"
+    assert metadata is not None
+    assert metadata.provider_id == "test-google"
+    assert metadata.model_name == "gemini-embedding-001"
+    provider.generate_completion.assert_awaited_once_with(
+        {"model": "gemini-embedding-001", "input": "Hello embeddings"},
+        "/v1/embeddings",
     )
 
 

--- a/tests/unit/test_new_integrations.py
+++ b/tests/unit/test_new_integrations.py
@@ -468,7 +468,7 @@ async def test_google_genai_generate_completion_accepts_embeddings_endpoint():
     provider._build_completion_context = AsyncMock(return_value=context)
     provider._run_completion_request = AsyncMock(
         return_value=SimpleNamespace(
-            embeddings=[SimpleNamespace(values=[0.1, 0.2, 0.3])],
+            embedding=SimpleNamespace(values=[0.1, 0.2, 0.3]),
             metadata=SimpleNamespace(billable_character_count=7),
         )
     )
@@ -493,6 +493,48 @@ async def test_google_genai_generate_completion_accepts_embeddings_endpoint():
     assert isinstance(build_args[1], GoogleGenAICompletionContext)
     assert build_args[1].original_model == "gemini-embedding-001"
     assert build_args[2] == "/v1/embeddings"
+
+
+@pytest.mark.asyncio
+async def test_google_genai_run_completion_request_batches_embeddings_and_tolerates_token_preflight():
+    provider = _make_google_provider()
+    provider._rate_limiter.acquire_slot = AsyncMock()
+    provider._rate_limiter.release_slot = AsyncMock()
+
+    client = Mock()
+    client.models = Mock()
+    client.models.count_tokens = Mock(
+        side_effect=[
+            SimpleNamespace(total_tokens=2),
+            SimpleNamespace(total_tokens=3),
+        ]
+    )
+    client.models.embed_content = Mock(
+        side_effect=[
+            SimpleNamespace(embedding=SimpleNamespace(values=[0.1, 0.2])),
+            SimpleNamespace(embedding=SimpleNamespace(values=[0.3, 0.4])),
+        ]
+    )
+    context = GoogleGenAICompletionContext(
+        original_model="gemini-embedding-001",
+        observation_id="obs-456",
+        endpoint="/v1/embeddings",
+        request_kind="embed_content",
+        model_name="gemini-embedding-001",
+        api_key="test-key",
+        api_key_suffix="abcd1234",
+        client=client,
+        genai_request={"contents": ["one", "two"], "config": None},
+    )
+
+    response = await provider._run_completion_request(context)
+
+    assert provider._rate_limiter.acquire_slot.await_count == 1
+    assert provider._rate_limiter.release_slot.await_count == 1
+    assert client.models.count_tokens.call_count == 2
+    assert client.models.embed_content.call_count == 2
+    assert context.input_token_count == 5
+    assert [embedding.values for embedding in response.embeddings] == [[0.1, 0.2], [0.3, 0.4]]
 
 
 @pytest.mark.asyncio
@@ -1412,6 +1454,11 @@ async def test_openai_provider_discovers_models_from_live_endpoint(mock_client):
 
     assert [model.id for model in models] == ["gpt-4o@test-openai"]
     assert models[0].metadata["owned_by"] == "openai"
+
+
+def test_openai_provider_embedding_backfill_gate_matches_canonical_host():
+    assert _make_openai_provider(url="https://api.openai.com/v1")._should_include_static_openai_embedding_models() is True
+    assert _make_openai_provider()._should_include_static_openai_embedding_models() is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_redis_backend.py
+++ b/tests/unit/test_redis_backend.py
@@ -58,6 +58,23 @@ def test_log_record_parses_fields_and_loads_blob_bodies(monkeypatch):
     assert record.response_body == b'{"output": true}'
 
 
+def test_log_record_marks_missing_blob_storage_as_storage_error(monkeypatch):
+    monkeypatch.setattr(storage_module, "get_blob_storage", lambda: None)
+
+    record = LogRecord(
+        {
+            "request_id": "req-1",
+            "request_body_key": "req-body",
+            "response_body_key": "resp-body",
+        }
+    )
+
+    assert record.request_body is None
+    assert record.response_body is None
+    assert record.request_body_status == "storage_error"
+    assert record.response_body_status == "storage_error"
+
+
 def test_log_record_normalizes_pending_and_invalid_values(monkeypatch):
     monkeypatch.setattr(storage_module, "get_blob_storage", lambda: FakeBlobStorage({}))
 


### PR DESCRIPTION
What changed
- Added `/v1/embeddings` support through the router.
- Enabled Google GenAI embedding models and request handling.
- Exposed OpenAI embedding models in `openai-main` so they are routable.
- Updated request-detail and Redis logging paths so embedding requests retain body visibility.
- Updated tests and status tracking.

Why
- The router needed to support embeddings for both Google GenAI and OpenAI providers, and the model listings had to expose embedding-capable models instead of hiding them.

Validation
- Live smoke on the restarted local router returned `200` for Google embeddings.
- Live smoke on the restarted local router returned `200` for OpenAI embeddings.
- Request logs show both request and response bodies available for the embedding requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible `POST /v1/embeddings`, including end-to-end Google GenAI embeddings wiring.
* **Bug Fixes**
  * Enhanced request detail pages to display clearer request/response body availability states (including missing/unavailable/not found).
  * Reduced duplicate embedding model entries during model discovery/backfill.
* **Security**
  * Ensured `POST /v1/embeddings` uses the standard request authentication verification flow.
* **Tests**
  * Added/expanded unit tests covering embeddings routing, conversions, responses, and body-status handling.
* **Documentation**
  * Updated the roadmap/status notes to reflect embeddings endpoint progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->