### PR TITLE
Use Redis rotary selection for Google API keys

### DIFF
--- a/smolrouter/database.py
+++ b/smolrouter/database.py
@@ -1047,6 +1047,16 @@ class ApiKeyQuota:
         return await RedisApiKeyQuota.increment_usage(api_key, provider_id, model_name, request_count, token_count)
 
     @staticmethod
+    async def select_google_api_key(
+        provider_id: str,
+        model_name: str,
+        api_keys: list[str],
+        model_limit: int,
+    ):
+        """Select the next eligible Google API key using Redis-backed serial rotary state."""
+        return await RedisApiKeyQuota.select_google_api_key(provider_id, model_name, api_keys, model_limit)
+
+    @staticmethod
     async def get_provider_usage(provider_id: str):
         """Get all quota entries for a provider"""
         return await RedisApiKeyQuota.get_provider_usage(provider_id)

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -1154,9 +1154,19 @@ class GoogleGenAIProvider(IModelProvider):
             return
 
         quota_percentage = (quota.requests_today / model_limit) * 100
-        if quota.requests_today >= model_limit:
+        if quota.quota_exhausted_at is not None:
             logger.error(
                 f"🚫 API key {redact_secret(api_key)} / {model_name} DAILY LIMIT REACHED: {quota.requests_today}/{model_limit}"
+            )
+        elif quota.requests_today >= model_limit:
+            logger.warning(
+                "API key %s / %s exceeded configured daily estimate after a successful request: %s/%s (%.1f%%). "
+                "Not treating this as confirmed exhaustion without a provider 429.",
+                redact_secret(api_key),
+                model_name,
+                quota.requests_today,
+                model_limit,
+                quota_percentage,
             )
         elif quota.requests_today >= (model_limit * 0.8):
             logger.warning(
@@ -3232,7 +3242,11 @@ class GoogleGenAIProvider(IModelProvider):
 
             model_limit = self.get_model_daily_limit(model)
             quota_percentage = (quota.requests_today / model_limit) * 100
-            is_exhausted = quota.requests_today >= model_limit or quota.quota_exhausted_at is not None
+            # Requests can legitimately exceed our configured estimate if Google's
+            # live limit changed or our heuristic is conservative. Only a provider-
+            # confirmed exhaustion marker should surface as "exhausted".
+            is_exhausted = quota.quota_exhausted_at is not None
+            daily_limit_estimate_exceeded = quota.requests_today >= model_limit
             last_request = _format_optional_datetime(quota.updated_at)
             quota_exhausted_at = _format_optional_datetime(quota.quota_exhausted_at)
 
@@ -3245,6 +3259,7 @@ class GoogleGenAIProvider(IModelProvider):
                 "quota_percentage": quota_percentage,
                 "quota_exhausted": is_exhausted,
                 "quota_exhausted_at": quota_exhausted_at,
+                "daily_limit_estimate_exceeded": daily_limit_estimate_exceeded,
                 "status": _quota_status(quota.invalid_key, is_exhausted),
             }
 

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -358,7 +358,7 @@ class GoogleGenAIProvider(IModelProvider):
             enabled=self.config.rate_limiting_enabled,
         )
 
-        # Proxy pool round-robin counter (thread-safe via atomicity of +=)
+        # Proxy pool round-robin counter
         self._proxy_pool_index = 0
         self._proxy_health: Dict[str, ProxyHealthStatus] = {}
         self._proxy_health_task: Optional[asyncio.Task] = None
@@ -909,207 +909,65 @@ class GoogleGenAIProvider(IModelProvider):
         return quota
 
     async def _select_best_api_key(self, model_name: str) -> str:
-        """
-        Select the API key with lowest usage for the given model.
+        """Select the next eligible API key in serial rotary order for this model."""
+        selection = await ApiKeyQuota.select_google_api_key(
+            provider_id=self.config.name,
+            model_name=model_name,
+            api_keys=self.config.api_keys,
+            model_limit=self.get_model_daily_limit(model_name),
+        )
 
-        Returns the first key from the set of keys with the lowest request count FOR THIS MODEL.
-        Order among equals doesn't matter - just consistent selection.
-        """
-        # Group keys by their request count for THIS MODEL, excluding exhausted/error keys
-        available_keys = []
-        exhausted_keys = []
-        error_prone_keys = []
-        cooling_down_keys: List[tuple[str, datetime]] = []
-        pacific_date = _current_pacific_date()
+        if selection["status"] == "ok":
+            selected_index = selection.get("selected_index")
+            if selected_index is None or not (0 <= selected_index < len(self.config.api_keys)):
+                raise RuntimeError(
+                    f"Redis returned invalid Google key index for {self.config.name}/{model_name}: {selected_index}"
+                )
 
-        for key in self.config.api_keys:
-            quota = await self._get_quota_record(key, model_name)
-            model_limit = self.get_model_daily_limit(model_name)
-            actual_requests_today = self._classify_api_key_for_model(
-                quota,
-                key,
+            best_key = self.config.api_keys[selected_index]
+            logger.debug(
+                "Selected API key %s for %s via Redis rotary slot %s/%s",
+                redact_secret(best_key),
                 model_name,
-                pacific_date,
-                model_limit,
-                exhausted_keys,
-                error_prone_keys,
-                cooling_down_keys,
+                selected_index + 1,
+                len(self.config.api_keys),
+            )
+            return best_key
+
+        # Under rotary selection, request-path exclusion should stay narrow: explicit invalid keys,
+        # active per-minute cooldowns, and observed same-day exhaustion. Favor availability over
+        # aggressive predictive benching from dead-reckoned counters.
+        if selection["status"] in {"no_keys", "all_invalid"}:
+            raise RuntimeError(
+                f"No usable Google API keys available for provider {self.config.name} / model {model_name} "
+                f"(status={selection['status']}, invalid={int(selection.get('invalid_count') or 0)})"
             )
 
-            if actual_requests_today is None:
-                continue
+        total_keys = len(self.config.api_keys)
+        invalid_count = int(selection.get("invalid_count") or 0)
+        cooling_down_count = int(selection.get("cooling_down_count") or 0)
+        exhausted_count = int(selection.get("exhausted_count") or 0)
+        retry_after = int(selection.get("retry_after_seconds") or 0)
 
-            available_keys.append((key, actual_requests_today))
+        logger.error(f"🚫 ALL {total_keys} API KEYS UNAVAILABLE FOR MODEL {model_name}:")
+        logger.error(f"   - Invalid: {invalid_count} keys")
+        logger.error(f"   - Quota exhausted: {exhausted_count} keys")
+        logger.error(f"   - Cooling down (per-minute): {cooling_down_count} keys")
 
-        if not available_keys:
-            # All keys exhausted for this model - provide detailed status
-            total_keys = len(self.config.api_keys)
-            logger.error(f"🚫 ALL {total_keys} API KEYS EXHAUSTED FOR MODEL {model_name}:")
-            logger.error(f"   - Quota exhausted: {len(exhausted_keys)} keys")
-            logger.error(f"   - Error-prone: {len(error_prone_keys)} keys")
-            logger.error(f"   - Cooling down (per-minute): {len(cooling_down_keys)} keys")
-
-            # Calculate seconds until quota reset (midnight Pacific time)
-            now_pacific = datetime.now(PACIFIC_TZ)
-            tomorrow_pacific = (now_pacific + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
-            seconds_until_reset = int((tomorrow_pacific - now_pacific).total_seconds())
-
-            # If keys are only cooling down (transient per-minute limits), the soonest-expiring
-            # one is usable again far sooner than midnight. Prefer it over a midnight reset so we
-            # report an accurate retry hint and, in the fallback, don't hammer api_keys[0].
-            soonest_cooldown_key, soonest_cooldown_until = self._soonest_cooldown(cooling_down_keys)
-            cooldown_remaining = None
-
-            if soonest_cooldown_until is not None:
-                cooldown_remaining = max(int((soonest_cooldown_until - self._utc_now()).total_seconds()), 0)
-                logger.warning(
-                    "⏳ All keys busy for %s; soonest key recovers in ~%ss (per-minute cooldown)",
-                    model_name,
-                    cooldown_remaining,
-                )
-            else:
-                logger.error(f"⏰ All API keys exhausted. Quota resets in {seconds_until_reset}s at midnight Pacific")
-
-            # Only raise predictive 429 if enabled
-            if self.config.predictive_429_enabled:
-                # Raise a specific exception that the container can catch and convert to 429
-                from google.api_core.exceptions import ResourceExhausted
-
-                retry_after = (
-                    cooldown_remaining if cooldown_remaining is not None else seconds_until_reset
-                )
-                raise ResourceExhausted(
-                    f"All {total_keys} API keys exhausted for model {model_name}. "
-                    f"Retry in {retry_after} seconds.",
-                    errors=[{"reason": "QUOTA_EXHAUSTED", "retry_after_seconds": retry_after}],
-                )
-
-            # Predictive 429 disabled - fall back and let the API handle the error. Prefer the
-            # key whose per-minute cooldown expires soonest (least-bad option) rather than always
-            # api_keys[0], which is what caused every request to pile onto key #1.
-            if soonest_cooldown_key is not None:
-                logger.warning(
-                    "⚠️ Predictive 429 disabled - falling back to soonest-recovering key %s for %s",
-                    redact_secret(soonest_cooldown_key),
-                    model_name,
-                )
-                return soonest_cooldown_key
-
+        if cooling_down_count > 0:
             logger.warning(
-                "⚠️ Predictive 429 disabled - using first API key despite quota tracking showing exhaustion"
+                "⏳ All keys busy for %s; soonest key recovers in ~%ss (per-minute cooldown)",
+                model_name,
+                retry_after,
             )
-            return self.config.api_keys[0]
+        else:
+            logger.error(f"⏰ All API keys exhausted. Quota resets in {retry_after}s at midnight Pacific")
 
-        # Sort by request count, then by key name for consistent ordering
-        available_keys.sort(key=lambda x: (x[1], x[0]))
-
-        # Find all keys with the lowest usage count
-        lowest_count = available_keys[0][1]
-        lowest_usage_keys = [key for key, count in available_keys if count == lowest_count]
-
-        # Random selection amongst equals (mitigation for when quota tracking is broken)
-        best_key = secrets.choice(lowest_usage_keys)
-
-        logger.debug(
-            f"Selected API key {redact_secret(best_key)} for {model_name} with {lowest_count} requests today "
-            f"({len(lowest_usage_keys)} keys at this usage level)"
+        raise ResourceExhausted(
+            f"All {total_keys} API keys exhausted for model {model_name}. "
+            f"Retry in {retry_after} seconds.",
+            errors=[{"reason": "QUOTA_EXHAUSTED", "retry_after_seconds": retry_after}],
         )
-
-        return best_key
-
-    def _classify_api_key_for_model(
-        self,
-        quota: QuotaRecord,
-        key: str,
-        model_name: str,
-        pacific_date: str,
-        model_limit: int,
-        exhausted_keys: List[str],
-        error_prone_keys: List[str],
-        cooling_down_keys: Optional[List[tuple[str, datetime]]] = None,
-    ) -> Optional[int]:
-        """Return the effective daily request count for a quota record, or None if it should be skipped."""
-        # Skip permanently invalid keys first.
-        if quota.invalid_key:
-            logger.debug(f"API key {redact_secret(key)} marked as invalid, skipping")
-            return None
-
-        actual_requests_today = quota.requests_today if quota.last_reset_date == pacific_date else 0
-
-        if actual_requests_today >= model_limit:
-            exhausted_keys.append(key)
-            logger.debug(
-                f"API key {redact_secret(key)} exhausted for {model_name} ({actual_requests_today}/{model_limit}) reset_date={quota.last_reset_date} today={pacific_date}"
-            )
-            return None
-
-        if quota.error_count > 20:  # Increased threshold
-            error_prone_keys.append(key)
-            logger.debug(f"API key {redact_secret(key)} too many errors for {model_name} ({quota.error_count})")
-            return None
-
-        # Transient per-minute cooldown: skip until the window passes, but record it so the
-        # caller can fall back to the soonest-recovering key instead of always api_keys[0].
-        cooldown_until = self._active_cooldown_until(quota)
-        if cooldown_until is not None:
-            if cooling_down_keys is not None:
-                cooling_down_keys.append((key, cooldown_until))
-            logger.debug(
-                f"API key {redact_secret(key)} cooling down for {model_name} until {cooldown_until.isoformat()}, skipping"
-            )
-            return None
-
-        if self._is_recent_quota_exhaustion(quota, key, model_name, pacific_date):
-            return None
-
-        return actual_requests_today
-
-    def _active_cooldown_until(self, quota: QuotaRecord) -> Optional[datetime]:
-        """Return the cooldown expiry if the key is still within a per-minute cooldown, else None.
-
-        ``quota_cooldown_until`` is always an aware-UTC datetime (or None): persisted values
-        pass through ``_normalize_datetime`` and in-memory values are set from ``_utc_now()``,
-        so we can compare directly in UTC without a timezone conversion.
-        """
-        cooldown_until = getattr(quota, "quota_cooldown_until", None)
-        if not cooldown_until:
-            return None
-        if cooldown_until > self._utc_now():
-            return cooldown_until
-        return None
-
-    @staticmethod
-    def _soonest_cooldown(
-        cooling_down_keys: List[tuple[str, datetime]],
-    ) -> tuple[Optional[str], Optional[datetime]]:
-        """Return the (key, cooldown_until) pair that recovers soonest, or (None, None)."""
-        if not cooling_down_keys:
-            return None, None
-        key, until = min(cooling_down_keys, key=lambda item: item[1])
-        return key, until
-
-    def _is_recent_quota_exhaustion(self, quota: QuotaRecord, key: str, model_name: str, pacific_date: str) -> bool:
-        """Check whether a quota exhaustion timestamp is still current for the Pacific day."""
-        if not quota.quota_exhausted_at:
-            return False
-
-        try:
-            quota_exhausted_pacific = _to_pacific_datetime(quota.quota_exhausted_at, assume_utc=True)
-        except (ValueError, TypeError, AttributeError):
-            logger.warning("API key %s has malformed quota_exhausted_at, allowing", redact_secret(key))
-            return False
-
-        exhausted_date = quota_exhausted_pacific.strftime("%Y-%m-%d")
-        if exhausted_date == pacific_date:
-            logger.debug(
-                f"API key {redact_secret(key)} exhausted TODAY for {model_name} at {quota_exhausted_pacific.strftime('%H:%M')}, skipping"
-            )
-            return True
-
-        logger.debug(
-            f"API key {redact_secret(key)} exhaustion from {exhausted_date} is stale (today is {pacific_date}), allowing"
-        )
-        return False
 
     async def _update_api_key_stats(
         self,
@@ -2918,6 +2776,9 @@ class GoogleGenAIProvider(IModelProvider):
         if endpoint != OPENAI_IMAGES_ENDPOINT:
             raise ValueError(f"Unsupported endpoint for image generation: {endpoint}")
 
+        # Validate request contract first so malformed image requests get
+        # deterministic input validation errors before transport/key/proxy
+        # selection can fail for reasons unrelated to the image payload.
         context = GoogleGenAICompletionContext(
             original_model=openai_request.get("model", ""),
             observation_id=f"obs_{uuid.uuid4().hex[:12]}",
@@ -2925,10 +2786,6 @@ class GoogleGenAIProvider(IModelProvider):
             request_kind="generate_images",
         )
         context.model_name = self._normalize_model_name(openai_request.get("model", ""))
-
-        # Validate request contract first so malformed image requests get
-        # deterministic input validation errors before transport/key/proxy
-        # selection can fail for reasons unrelated to the image payload.
         self._validate_image_generation_request(openai_request, context)
 
         try:

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -259,7 +259,8 @@ class GoogleGenAIConfig(ProviderConfig):
     proxy_pool: Optional[List[Optional["ProxyConfig"]]] = None
     proxy_pool_enabled: bool = False  # Master switch for proxy pooling
 
-    # Predictive 429 configuration (defaults to disabled)
+    # Deprecated compatibility flag. Rotary selection no longer preempts keys from
+    # dead-reckoned usage; runtime handling is driven by observed cooldown/exhaustion.
     predictive_429_enabled: bool = False
 
     def __post_init__(self):
@@ -367,7 +368,7 @@ class GoogleGenAIProvider(IModelProvider):
 
         logger.info(f"Initialized GoogleGenAI provider with {len(self.config.api_keys)} API keys")
         logger.info(f"Rate limiting: {'enabled' if self.config.rate_limiting_enabled else 'disabled'}")
-        logger.info(f"Predictive 429: {'enabled' if self.config.predictive_429_enabled else 'disabled'}")
+        logger.info("Predictive 429 config: deprecated/ignored; rotary selection uses observed cooldown/exhaustion only")
         if self.config.proxy_pool_enabled and self.config.proxy_pool:
             pool_size = len(self.config.proxy_pool)
             direct_count = sum(1 for p in self.config.proxy_pool if p is None)
@@ -1005,15 +1006,15 @@ class GoogleGenAIProvider(IModelProvider):
 
             # Check if this is a quota exhaustion error
             elif self._is_quota_exhausted_error(error_message):
-                cooldown_seconds = self._quota_cooldown_seconds(error_message)
-                if cooldown_seconds is not None:
-                    # Transient per-minute (RPM) limit: short cooldown, not an all-day bench.
+                if self._is_per_day_quota_error(error_message):
+                    # Only explicit per-day (RPD) signals should hard-bench a key.
+                    await self._record_quota_exhaustion(ApiKeyQuota, quota, api_key, model_name, error_message)
+                else:
+                    # Explicit RPM and ambiguous quota 429s are treated as transient cooldowns.
+                    cooldown_seconds = self._quota_cooldown_seconds(error_message)
                     await self._record_rate_limit_cooldown(
                         ApiKeyQuota, quota, api_key, model_name, error_message, cooldown_seconds
                     )
-                else:
-                    # Per-day (RPD) / unrecognized quota exhaustion: bench until midnight Pacific.
-                    await self._record_quota_exhaustion(ApiKeyQuota, quota, api_key, model_name, error_message)
             else:
                 await self._record_regular_error(ApiKeyQuota, quota, api_key, model_name, error_message, status_code)
 
@@ -1078,12 +1079,12 @@ class GoogleGenAIProvider(IModelProvider):
         error_message: str,
         cooldown_seconds: float,
     ) -> None:
-        """Handle a transient per-minute (RPM) 429.
+        """Handle a transient quota 429.
 
-        Sets a short cooldown window (driven by Google's RetryInfo) after which the key
-        returns to the selection pool, instead of benching it until midnight Pacific the
-        way genuine per-day (RPD) exhaustion does. This is the fix for RPM 429s cascading
-        into "all keys exhausted" and pinning every request onto api_keys[0].
+        Sets a short cooldown window after which the key returns to the selection pool,
+        instead of benching it until midnight Pacific. Explicit RPM uses Google's
+        RetryInfo when available; ambiguous quota 429s also land here because they are
+        too weak a signal to justify all-day exclusion.
         """
         cooldown_until = self._utc_now() + timedelta(seconds=cooldown_seconds)
         quota.mark_rate_limited(cooldown_until, error=error_message)
@@ -1096,7 +1097,7 @@ class GoogleGenAIProvider(IModelProvider):
             logger.exception("Failed to persist quota cooldown to Redis")
 
         logger.warning(
-            "🕒 API key %s rate limited (per-minute) for %s: cooling down %.0fs (until %s)",
+            "🕒 API key %s rate limited for %s: cooling down %.0fs (until %s)",
             redact_secret(api_key),
             model_name,
             cooldown_seconds,
@@ -1242,19 +1243,14 @@ class GoogleGenAIProvider(IModelProvider):
         error_lower = error_msg.lower()
         return "perday" in error_lower or "per day" in error_lower or "requests per day" in error_lower
 
-    def _quota_cooldown_seconds(self, error_msg: Optional[str] = None) -> Optional[float]:
-        """Return a transient cooldown (seconds) for a quota 429, or None for all-day exhaustion.
+    def _quota_cooldown_seconds(self, error_msg: Optional[str] = None) -> float:
+        """Return a transient cooldown (seconds) for a quota 429.
 
         - Explicit per-minute (RPM) → cooldown driven by Google's retryDelay (or default).
-        - Everything else (explicit per-day, or no PerMinute quotaId) → None, i.e. the
-          caller treats it as all-day exhaustion. Real Google free-tier 429s always carry
-          a quotaId, so RPM is reliably detectable; we stay conservative for anything else.
+        - Ambiguous quota 429s → also transient cooldown, because they are not strong
+          enough evidence for all-day exhaustion.
+        - Explicit per-day (RPD) is handled by the caller before reaching this helper.
         """
-        if not self._is_per_minute_quota_error(error_msg):
-            return None
-        if self._is_per_day_quota_error(error_msg):
-            return None
-
         retry_delay = self._extract_retry_delay(error_msg)
         base = retry_delay if retry_delay is not None else self.DEFAULT_RPM_COOLDOWN_SECONDS
         return base + self.RPM_COOLDOWN_BUFFER_SECONDS

--- a/smolrouter/google_genai_provider.py
+++ b/smolrouter/google_genai_provider.py
@@ -27,7 +27,7 @@ from google.api_core.exceptions import ResourceExhausted, PermissionDenied, Inva
 
 from .config_loading import load_config_entries
 from .interfaces import IModelProvider, ModelInfo, ProviderConfig, ProxyConfig
-from .secret_store import redact_secret, resolve_config_file, secrets_search_paths
+from .secret_store import redact_secret, resolve_config_file, secret_suffix, secrets_search_paths
 from .database import ApiKeyQuota
 from .redis_backend import QuotaRecord
 from .rate_limiter import GoogleGenAIRequestFunnel
@@ -2509,7 +2509,7 @@ class GoogleGenAIProvider(IModelProvider):
         context.endpoint = endpoint
         context.model_name = self._normalize_model_name(openai_request.get("model", ""))
         context.api_key = await self._select_best_api_key(context.model_name)
-        context.api_key_suffix = redact_secret(context.api_key)
+        context.api_key_suffix = secret_suffix(context.api_key)
         context.api_key_index, context.api_key_total = self._resolve_api_key_position(context.api_key)
         context.proxy_config, context.proxy_pool_index, context.pool_info = self._select_proxy_configuration(
             context.model_name
@@ -2849,7 +2849,7 @@ class GoogleGenAIProvider(IModelProvider):
         context.tts_audio_format = self._get_tts_audio_format(openai_request) if context.tts_request else "pcm"
         context.model_name, context.genai_request = self._convert_openai_to_genai_request(openai_request, endpoint)
         context.api_key = await self._select_best_api_key(context.model_name)
-        context.api_key_suffix = redact_secret(context.api_key)
+        context.api_key_suffix = secret_suffix(context.api_key)
         context.api_key_index, context.api_key_total = self._resolve_api_key_position(context.api_key)
         context.proxy_config, context.proxy_pool_index, context.pool_info = self._select_proxy_configuration(
             context.model_name

--- a/smolrouter/redis_backend.py
+++ b/smolrouter/redis_backend.py
@@ -8,7 +8,7 @@ for high-throughput concurrent operations, replacing SQLite bottlenecks.
 import logging
 import os
 import hashlib
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Any, Mapping, TypedDict, Unpack
 from zoneinfo import ZoneInfo
 
@@ -59,6 +59,95 @@ for _, request_id in ipairs(ids) do
 end
 
 return records
+"""
+GOOGLE_ROTARY_SELECTOR_LUA_SCRIPT = """
+local counter_key = KEYS[1]
+local provider_id = ARGV[1]
+local model_name = ARGV[2]
+local today = ARGV[3]
+local now_iso = ARGV[4]
+local model_limit = tonumber(ARGV[5]) or 0
+local key_count = #ARGV - 5
+
+if key_count <= 0 then
+    return {
+        "status", "no_keys",
+        "selected_index", "",
+        "selected_key_hash", "",
+        "invalid_count", "0",
+        "cooling_down_count", "0",
+        "exhausted_count", "0",
+        "soonest_cooldown_until", ""
+    }
+end
+
+local counter = tonumber(redis.call("GET", counter_key) or "0")
+local invalid_key_set = "google_invalid_keys:" .. provider_id
+local invalid_count = 0
+local cooling_down_count = 0
+local exhausted_count = 0
+local soonest_cooldown_until = ""
+
+for offset = 0, key_count - 1 do
+    local idx = (counter + offset) % key_count
+    local key_hash = ARGV[6 + idx]
+    local quota_key = "quota:" .. provider_id .. ":" .. key_hash .. ":" .. model_name
+
+    if redis.call("SISMEMBER", invalid_key_set, key_hash) == 1 then
+        invalid_count = invalid_count + 1
+    else
+    local invalid_key = redis.call("HGET", quota_key, "invalid_key")
+    if invalid_key ~= "true" and invalid_key ~= "1" then
+        local last_reset = redis.call("HGET", quota_key, "last_reset")
+        if not last_reset or last_reset == "" then
+            last_reset = redis.call("HGET", quota_key, "last_reset_date")
+        end
+
+        local quota_exhausted_at = redis.call("HGET", quota_key, "quota_exhausted_at")
+        local cooldown_until = redis.call("HGET", quota_key, "quota_cooldown_until")
+        local reset_is_today = last_reset == today
+        local quota_exhausted_today = reset_is_today and quota_exhausted_at and quota_exhausted_at ~= ""
+        local is_cooling_down = cooldown_until and cooldown_until ~= "" and cooldown_until > now_iso
+
+        if is_cooling_down then
+            cooling_down_count = cooling_down_count + 1
+            if soonest_cooldown_until == "" or cooldown_until < soonest_cooldown_until then
+                soonest_cooldown_until = cooldown_until
+            end
+        elseif quota_exhausted_today then
+            exhausted_count = exhausted_count + 1
+        else
+            redis.call("SET", counter_key, tostring(idx + 1))
+            return {
+                "status", "ok",
+                "selected_index", tostring(idx),
+                "selected_key_hash", key_hash,
+                "invalid_count", tostring(invalid_count),
+                "cooling_down_count", tostring(cooling_down_count),
+                "exhausted_count", tostring(exhausted_count),
+                "soonest_cooldown_until", soonest_cooldown_until
+            }
+        end
+    else
+        invalid_count = invalid_count + 1
+    end
+    end
+end
+
+local status = "none_available"
+if invalid_count == key_count then
+    status = "all_invalid"
+end
+
+return {
+    "status", status,
+    "selected_index", "",
+    "selected_key_hash", "",
+    "invalid_count", tostring(invalid_count),
+    "cooling_down_count", tostring(cooling_down_count),
+    "exhausted_count", tostring(exhausted_count),
+    "soonest_cooldown_until", soonest_cooldown_until
+}
 """
 REQUEST_LOG_CREATE_OPTION_KEYS = frozenset(
     {
@@ -114,6 +203,13 @@ REQUEST_LOG_COMPLETION_NUMERIC_FIELDS = ("api_key_index", "api_key_total")
 
 def _current_pacific_date() -> str:
     return datetime.now(PACIFIC_TZ).strftime("%Y-%m-%d")
+
+
+def _seconds_until_pacific_midnight(now_utc: Optional[datetime] = None) -> int:
+    now = now_utc or datetime.now(timezone.utc)
+    now_pacific = now.astimezone(PACIFIC_TZ)
+    tomorrow_pacific = (now_pacific + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    return int((tomorrow_pacific - now_pacific).total_seconds())
 
 
 def _to_pacific_datetime(value: datetime, assume_utc: bool = False) -> datetime:
@@ -998,6 +1094,7 @@ class RedisApiKeyQuota:
     """Redis-based API key quota tracking with atomic counters"""
 
     _script_sha: Optional[str] = None  # Class variable to store loaded script SHA
+    _google_selector_script_sha: Optional[str] = None
     _script_initialized: bool = False
     _lua_disabled: bool = False  # When true, use pipeline fallback (e.g., FakeRedis/tests)
 
@@ -1022,8 +1119,13 @@ class RedisApiKeyQuota:
 
         try:
             cls._script_sha = await redis_client.script_load(QUOTA_UPDATE_SCRIPT)
+            cls._google_selector_script_sha = await redis_client.script_load(GOOGLE_ROTARY_SELECTOR_LUA_SCRIPT)
             cls._script_initialized = True
-            logger.info(f"✅ Lua script loaded successfully: {cls._script_sha}")
+            logger.info(
+                "✅ Lua scripts loaded successfully: quota=%s selector=%s",
+                cls._script_sha,
+                cls._google_selector_script_sha,
+            )
         except Exception as e:
             logger.exception("❌ FATAL: Failed to load Lua script into Redis")
             logger.critical("⚠️  Server CANNOT start without functional quota tracking")
@@ -1033,6 +1135,14 @@ class RedisApiKeyQuota:
     def hash_api_key(api_key: str) -> str:
         """Create hash of API key for identification"""
         return hashlib.sha256(api_key.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def google_rotary_counter_key(provider_id: str, model_name: str) -> str:
+        return f"google_rr:{provider_id}:{model_name}"
+
+    @staticmethod
+    def google_invalid_keys_key(provider_id: str) -> str:
+        return f"google_invalid_keys:{provider_id}"
 
     @staticmethod
     async def get_or_create_quota(
@@ -1191,6 +1301,176 @@ class RedisApiKeyQuota:
 
         return quota_data
 
+    @classmethod
+    async def _select_google_api_key_with_pipeline_fallback(
+        cls,
+        client: Any,
+        provider_id: str,
+        model_name: str,
+        key_hashes: List[str],
+        today: str,
+        now_iso: str,
+        model_limit: int,
+    ) -> Dict[str, Any]:
+        counter_key = cls.google_rotary_counter_key(provider_id, model_name)
+        invalid_key_set = cls.google_invalid_keys_key(provider_id)
+        counter_raw = await client.get(counter_key)
+        counter = int(counter_raw or 0)
+        now_dt = _normalize_datetime(now_iso) or datetime.now(timezone.utc)
+        invalid_key_hashes = {str(key_hash) for key_hash in (await client.smembers(invalid_key_set))}
+        invalid_count = 0
+        soonest_cooldown_until: Optional[datetime] = None
+        cooling_down_count = 0
+        exhausted_count = 0
+
+        for offset in range(len(key_hashes)):
+            idx = (counter + offset) % len(key_hashes)
+            key_hash = key_hashes[idx]
+            quota_key = f"quota:{provider_id}:{key_hash}:{model_name}"
+
+            if key_hash in invalid_key_hashes:
+                invalid_count += 1
+                continue
+
+            quota_data = await client.hgetall(quota_key)
+
+            if not quota_data:
+                await client.set(counter_key, idx + 1)
+                return {
+                    "status": "ok",
+                    "selected_index": idx,
+                    "selected_key_hash": key_hash,
+                    "invalid_count": invalid_count,
+                    "cooling_down_count": cooling_down_count,
+                    "exhausted_count": exhausted_count,
+                    "soonest_cooldown_until": soonest_cooldown_until.isoformat() if soonest_cooldown_until else "",
+                    "retry_after_seconds": 0,
+                }
+
+            quota = QuotaRecord(quota_data)
+            if quota.invalid_key:
+                invalid_count += 1
+                continue
+
+            reset_is_today = quota.last_reset_date == today
+            if quota.quota_cooldown_until and quota.quota_cooldown_until > now_dt:
+                cooling_down_count += 1
+                if soonest_cooldown_until is None or quota.quota_cooldown_until < soonest_cooldown_until:
+                    soonest_cooldown_until = quota.quota_cooldown_until
+                continue
+
+            if reset_is_today and quota.quota_exhausted_at:
+                exhausted_count += 1
+                continue
+
+            await client.set(counter_key, idx + 1)
+            return {
+                "status": "ok",
+                "selected_index": idx,
+                "selected_key_hash": key_hash,
+                "invalid_count": invalid_count,
+                "cooling_down_count": cooling_down_count,
+                "exhausted_count": exhausted_count,
+                "soonest_cooldown_until": soonest_cooldown_until.isoformat() if soonest_cooldown_until else "",
+                "retry_after_seconds": 0,
+            }
+
+        retry_after_seconds = (
+            max(int((soonest_cooldown_until - now_dt).total_seconds()), 0) if soonest_cooldown_until else _seconds_until_pacific_midnight(now_dt)
+        )
+        status = "all_invalid" if invalid_count == len(key_hashes) else "none_available"
+        return {
+            "status": status,
+            "selected_index": None,
+            "selected_key_hash": "",
+            "invalid_count": invalid_count,
+            "cooling_down_count": cooling_down_count,
+            "exhausted_count": exhausted_count,
+            "soonest_cooldown_until": soonest_cooldown_until.isoformat() if soonest_cooldown_until else "",
+            "retry_after_seconds": retry_after_seconds,
+        }
+
+    @classmethod
+    async def select_google_api_key(
+        cls,
+        provider_id: str,
+        model_name: str,
+        api_keys: List[str],
+        model_limit: int,
+    ) -> Dict[str, Any]:
+        """Atomically select the next eligible Google API key in serial rotary order."""
+        if not api_keys:
+            return {
+                "status": "no_keys",
+                "selected_index": None,
+                "selected_key_hash": "",
+                "invalid_count": 0,
+                "cooling_down_count": 0,
+                "exhausted_count": 0,
+                "soonest_cooldown_until": "",
+                "retry_after_seconds": 0,
+            }
+
+        client = get_redis()
+        today = _current_pacific_date()
+        now_iso = datetime.now(timezone.utc).isoformat()
+        now_dt = _normalize_datetime(now_iso) or datetime.now(timezone.utc)
+        key_hashes = [cls.hash_api_key(api_key) for api_key in api_keys]
+        counter_key = cls.google_rotary_counter_key(provider_id, model_name)
+
+        if not cls._script_initialized or cls._google_selector_script_sha is None:
+            if not _is_lua_fallback_enabled(cls._lua_disabled):
+                error_msg = "❌ FATAL: Google selector script not initialized - call initialize_lua_script() during startup"
+                logger.critical(error_msg)
+                raise RuntimeError(error_msg)
+            return await cls._select_google_api_key_with_pipeline_fallback(
+                client, provider_id, model_name, key_hashes, today, now_iso, model_limit
+            )
+
+        try:
+            result = await client.evalsha(
+                cls._google_selector_script_sha,
+                1,
+                counter_key,
+                provider_id,
+                model_name,
+                today,
+                now_iso,
+                str(model_limit),
+                *key_hashes,
+            )
+            selection = _flat_pairs_to_dict(result)
+        except Exception as e:
+            if _should_use_increment_fallback(e, cls._lua_disabled):
+                return await cls._select_google_api_key_with_pipeline_fallback(
+                    client, provider_id, model_name, key_hashes, today, now_iso, model_limit
+                )
+            logger.exception("❌ FATAL: Google selector Lua script execution failed")
+            raise RuntimeError(f"Google selector BROKEN - Lua script failed: {e}") from e
+
+        selected_index_raw = selection.get("selected_index")
+        selected_index = int(selected_index_raw) if selected_index_raw not in REDIS_EMPTY_VALUES else None
+        soonest_cooldown_until = str(selection.get("soonest_cooldown_until") or "")
+        retry_after_seconds = 0
+        if selection.get("status") != "ok":
+            if soonest_cooldown_until:
+                cooldown_dt = _normalize_datetime(soonest_cooldown_until)
+                if cooldown_dt is not None:
+                    retry_after_seconds = max(int((cooldown_dt - now_dt).total_seconds()), 0)
+            if retry_after_seconds == 0:
+                retry_after_seconds = _seconds_until_pacific_midnight(now_dt)
+
+        return {
+            "status": str(selection.get("status") or "none_available"),
+            "selected_index": selected_index,
+            "selected_key_hash": str(selection.get("selected_key_hash") or ""),
+            "invalid_count": int(selection.get("invalid_count") or 0),
+            "cooling_down_count": int(selection.get("cooling_down_count") or 0),
+            "exhausted_count": int(selection.get("exhausted_count") or 0),
+            "soonest_cooldown_until": soonest_cooldown_until,
+            "retry_after_seconds": retry_after_seconds,
+        }
+
     @staticmethod
     async def get_provider_usage(provider_id: str) -> List["QuotaRecord"]:
         """Get all quota entries for a provider"""
@@ -1221,6 +1501,7 @@ class RedisApiKeyQuota:
 
         # Get all quota keys for this key hash
         quota_keys = await client.smembers(f"quotas:by_key:{api_key_hash}")
+        await client.sadd(RedisApiKeyQuota.google_invalid_keys_key(provider_name), api_key_hash)
 
         count = 0
         for quota_key in quota_keys:

--- a/smolrouter/redis_backend.py
+++ b/smolrouter/redis_backend.py
@@ -1324,74 +1324,80 @@ class RedisApiKeyQuota:
         counter = int(counter_raw or 0)
         now_dt = _normalize_datetime(now_iso) or datetime.now(timezone.utc)
         invalid_key_hashes = {str(key_hash) for key_hash in (await client.smembers(invalid_key_set))}
-        invalid_count = 0
+        counts = {"invalid": 0, "cooling_down": 0, "exhausted": 0}
         soonest_cooldown_until: Optional[datetime] = None
-        cooling_down_count = 0
-        exhausted_count = 0
 
         for offset in range(len(key_hashes)):
             idx = (counter + offset) % len(key_hashes)
             key_hash = key_hashes[idx]
-            quota_key = f"quota:{provider_id}:{key_hash}:{model_name}"
+            availability, cooldown_until = await cls._get_google_api_key_fallback_availability(
+                client, provider_id, model_name, key_hash, invalid_key_hashes, today, now_dt
+            )
 
-            if key_hash in invalid_key_hashes:
-                invalid_count += 1
-                continue
-
-            quota_data = await client.hgetall(quota_key)
-
-            if not quota_data:
-                await client.set(counter_key, idx + 1)
-                return {
-                    "status": "ok",
-                    "selected_index": idx,
-                    "selected_key_hash": key_hash,
-                    "invalid_count": invalid_count,
-                    "cooling_down_count": cooling_down_count,
-                    "exhausted_count": exhausted_count,
-                    "soonest_cooldown_until": soonest_cooldown_until.isoformat() if soonest_cooldown_until else "",
-                    "retry_after_seconds": 0,
-                }
-
-            quota = QuotaRecord(quota_data)
-            if quota.invalid_key:
-                invalid_count += 1
-                continue
-
-            reset_is_today = quota.last_reset_date == today
-            if quota.quota_cooldown_until and quota.quota_cooldown_until > now_dt:
-                cooling_down_count += 1
-                if soonest_cooldown_until is None or quota.quota_cooldown_until < soonest_cooldown_until:
-                    soonest_cooldown_until = quota.quota_cooldown_until
-                continue
-
-            if reset_is_today and quota.quota_exhausted_at:
-                exhausted_count += 1
+            if availability != "available":
+                counts[availability] += 1
+                if cooldown_until is not None:
+                    soonest_cooldown_until = cls._earlier_cooldown(soonest_cooldown_until, cooldown_until)
                 continue
 
             await client.set(counter_key, idx + 1)
-            return {
-                "status": "ok",
-                "selected_index": idx,
-                "selected_key_hash": key_hash,
-                "invalid_count": invalid_count,
-                "cooling_down_count": cooling_down_count,
-                "exhausted_count": exhausted_count,
-                "soonest_cooldown_until": soonest_cooldown_until.isoformat() if soonest_cooldown_until else "",
-                "retry_after_seconds": 0,
-            }
+            return cls._google_api_key_selection_result("ok", idx, key_hash, counts, soonest_cooldown_until, 0)
 
         retry_after_seconds = (
             max(int((soonest_cooldown_until - now_dt).total_seconds()), 0) if soonest_cooldown_until else _seconds_until_pacific_midnight(now_dt)
         )
-        status = "all_invalid" if invalid_count == len(key_hashes) else "none_available"
+        status = "all_invalid" if counts["invalid"] == len(key_hashes) else "none_available"
+        return cls._google_api_key_selection_result(status, None, "", counts, soonest_cooldown_until, retry_after_seconds)
+
+    @staticmethod
+    async def _get_google_api_key_fallback_availability(
+        client: Any,
+        provider_id: str,
+        model_name: str,
+        key_hash: str,
+        invalid_key_hashes: set[str],
+        today: str,
+        now_dt: datetime,
+    ) -> tuple[str, Optional[datetime]]:
+        """Classify one fallback key using the same order as the Lua selector."""
+        if key_hash in invalid_key_hashes:
+            return "invalid", None
+
+        quota_data = await client.hgetall(f"quota:{provider_id}:{key_hash}:{model_name}")
+        if not quota_data:
+            return "available", None
+
+        quota = QuotaRecord(quota_data)
+        if quota.invalid_key:
+            return "invalid", None
+        if quota.quota_cooldown_until and quota.quota_cooldown_until > now_dt:
+            return "cooling_down", quota.quota_cooldown_until
+        if quota.last_reset_date == today and quota.quota_exhausted_at:
+            return "exhausted", None
+        return "available", None
+
+    @staticmethod
+    def _earlier_cooldown(current: Optional[datetime], candidate: datetime) -> datetime:
+        if current is None or candidate < current:
+            return candidate
+        return current
+
+    @staticmethod
+    def _google_api_key_selection_result(
+        status: str,
+        selected_index: Optional[int],
+        selected_key_hash: str,
+        counts: Mapping[str, int],
+        soonest_cooldown_until: Optional[datetime],
+        retry_after_seconds: int,
+    ) -> Dict[str, Any]:
         return {
             "status": status,
-            "selected_index": None,
-            "selected_key_hash": "",
-            "invalid_count": invalid_count,
-            "cooling_down_count": cooling_down_count,
-            "exhausted_count": exhausted_count,
+            "selected_index": selected_index,
+            "selected_key_hash": selected_key_hash,
+            "invalid_count": counts["invalid"],
+            "cooling_down_count": counts["cooling_down"],
+            "exhausted_count": counts["exhausted"],
             "soonest_cooldown_until": soonest_cooldown_until.isoformat() if soonest_cooldown_until else "",
             "retry_after_seconds": retry_after_seconds,
         }
@@ -1410,16 +1416,9 @@ class RedisApiKeyQuota:
         rotary selection does not preemptively exclude keys by request count.
         """
         if not api_keys:
-            return {
-                "status": "no_keys",
-                "selected_index": None,
-                "selected_key_hash": "",
-                "invalid_count": 0,
-                "cooling_down_count": 0,
-                "exhausted_count": 0,
-                "soonest_cooldown_until": "",
-                "retry_after_seconds": 0,
-            }
+            return cls._google_api_key_selection_result(
+                "no_keys", None, "", {"invalid": 0, "cooling_down": 0, "exhausted": 0}, None, 0
+            )
 
         client = get_redis()
         today = _current_pacific_date()
@@ -1428,14 +1427,31 @@ class RedisApiKeyQuota:
         key_hashes = [cls.hash_api_key(api_key) for api_key in api_keys]
         counter_key = cls.google_rotary_counter_key(provider_id, model_name)
 
+        selection = await cls._run_google_api_key_selector(
+            client, counter_key, provider_id, model_name, key_hashes, today, now_iso, model_limit
+        )
+        return cls._format_google_api_key_selection(selection, now_dt)
+
+    @classmethod
+    async def _run_google_api_key_selector(
+        cls,
+        client: Any,
+        counter_key: str,
+        provider_id: str,
+        model_name: str,
+        key_hashes: List[str],
+        today: str,
+        now_iso: str,
+        model_limit: int,
+    ) -> Dict[str, Any]:
         if not cls._script_initialized or cls._google_selector_script_sha is None:
-            if not _is_lua_fallback_enabled(cls._lua_disabled):
-                error_msg = "❌ FATAL: Google selector script not initialized - call initialize_lua_script() during startup"
-                logger.critical(error_msg)
-                raise RuntimeError(error_msg)
-            return await cls._select_google_api_key_with_pipeline_fallback(
-                client, provider_id, model_name, key_hashes, today, now_iso, model_limit
-            )
+            if _is_lua_fallback_enabled(cls._lua_disabled):
+                return await cls._select_google_api_key_with_pipeline_fallback(
+                    client, provider_id, model_name, key_hashes, today, now_iso, model_limit
+                )
+            error_msg = "❌ FATAL: Google selector script not initialized - call initialize_lua_script() during startup"
+            logger.critical(error_msg)
+            raise RuntimeError(error_msg)
 
         try:
             result = await client.evalsha(
@@ -1449,26 +1465,21 @@ class RedisApiKeyQuota:
                 str(model_limit),
                 *key_hashes,
             )
-            selection = _flat_pairs_to_dict(result)
-        except Exception as e:
-            if _should_use_increment_fallback(e, cls._lua_disabled):
+        except Exception as error:
+            if _should_use_increment_fallback(error, cls._lua_disabled):
                 return await cls._select_google_api_key_with_pipeline_fallback(
                     client, provider_id, model_name, key_hashes, today, now_iso, model_limit
                 )
             logger.exception("❌ FATAL: Google selector Lua script execution failed")
-            raise RuntimeError(f"Google selector BROKEN - Lua script failed: {e}") from e
+            raise RuntimeError(f"Google selector BROKEN - Lua script failed: {error}") from error
+        return _flat_pairs_to_dict(result)
 
+    @staticmethod
+    def _format_google_api_key_selection(selection: Mapping[str, Any], now_dt: datetime) -> Dict[str, Any]:
         selected_index_raw = selection.get("selected_index")
         selected_index = int(selected_index_raw) if selected_index_raw not in REDIS_EMPTY_VALUES else None
         soonest_cooldown_until = str(selection.get("soonest_cooldown_until") or "")
-        retry_after_seconds = 0
-        if selection.get("status") != "ok":
-            if soonest_cooldown_until:
-                cooldown_dt = _normalize_datetime(soonest_cooldown_until)
-                if cooldown_dt is not None:
-                    retry_after_seconds = max(int((cooldown_dt - now_dt).total_seconds()), 0)
-            if retry_after_seconds == 0:
-                retry_after_seconds = _seconds_until_pacific_midnight(now_dt)
+        retry_after_seconds = RedisApiKeyQuota._google_api_key_retry_after(selection, soonest_cooldown_until, now_dt)
 
         return {
             "status": str(selection.get("status") or "none_available"),
@@ -1480,6 +1491,17 @@ class RedisApiKeyQuota:
             "soonest_cooldown_until": soonest_cooldown_until,
             "retry_after_seconds": retry_after_seconds,
         }
+
+    @staticmethod
+    def _google_api_key_retry_after(selection: Mapping[str, Any], cooldown_until: str, now_dt: datetime) -> int:
+        if selection.get("status") == "ok":
+            return 0
+        cooldown_dt = _normalize_datetime(cooldown_until) if cooldown_until else None
+        if cooldown_dt is not None:
+            retry_after_seconds = max(int((cooldown_dt - now_dt).total_seconds()), 0)
+            if retry_after_seconds:
+                return retry_after_seconds
+        return _seconds_until_pacific_midnight(now_dt)
 
     @staticmethod
     async def get_provider_usage(provider_id: str) -> List["QuotaRecord"]:

--- a/smolrouter/redis_backend.py
+++ b/smolrouter/redis_backend.py
@@ -66,6 +66,9 @@ local provider_id = ARGV[1]
 local model_name = ARGV[2]
 local today = ARGV[3]
 local now_iso = ARGV[4]
+-- Reserved for future predictive heuristics. Rotary selection intentionally
+-- does not preempt keys by request count; availability wins until a key is
+-- actually cooling down, exhausted for the day, or invalid.
 local model_limit = tonumber(ARGV[5]) or 0
 local key_count = #ARGV - 5
 
@@ -1312,6 +1315,9 @@ class RedisApiKeyQuota:
         now_iso: str,
         model_limit: int,
     ) -> Dict[str, Any]:
+        # Keep the fallback signature aligned with the Lua selector even though
+        # rotary selection no longer uses predictive request-count exclusion.
+        _ = model_limit
         counter_key = cls.google_rotary_counter_key(provider_id, model_name)
         invalid_key_set = cls.google_invalid_keys_key(provider_id)
         counter_raw = await client.get(counter_key)
@@ -1398,7 +1404,11 @@ class RedisApiKeyQuota:
         api_keys: List[str],
         model_limit: int,
     ) -> Dict[str, Any]:
-        """Atomically select the next eligible Google API key in serial rotary order."""
+        """Atomically select the next eligible Google API key in serial rotary order.
+
+        ``model_limit`` is intentionally threaded through for selector parity, but
+        rotary selection does not preemptively exclude keys by request count.
+        """
         if not api_keys:
             return {
                 "status": "no_keys",

--- a/smolrouter/secret_store.py
+++ b/smolrouter/secret_store.py
@@ -181,17 +181,26 @@ def get_facade_key_secrets(facade_key_id: str) -> List[str]:
     return list((load_facade_key_secrets() if facade_key_id else {}).get(facade_key_id, []))
 
 
-def redact_secret(value: str | None) -> str:
-    """Redact a secret for logging."""
+def secret_suffix(value: str | None, width: int = 8) -> str:
+    """Return a non-sensitive trailing fragment for correlation."""
 
     if not value:
-        return "***"
+        return ""
 
     text = value.strip()
     if not text:
-        return "***"
+        return ""
 
-    if len(text) <= 5:
-        return "***"
+    if len(text) <= width:
+        return text if len(text) > 4 else ""
 
-    return f"{text[:5]}…"
+    return text[-width:]
+
+
+def redact_secret(value: str | None) -> str:
+    """Redact a secret for logging."""
+
+    suffix = secret_suffix(value)
+    if not suffix:
+        return "***"
+    return f"…{suffix}"

--- a/tests/unit/test_google_genai_helpers.py
+++ b/tests/unit/test_google_genai_helpers.py
@@ -913,9 +913,14 @@ def test_quota_cooldown_seconds_per_minute_without_retry_delay(provider):
 
 
 def test_quota_cooldown_seconds_per_day_is_all_day(provider):
-    # RPD and ambiguous quota errors return None -> caller benches until midnight Pacific.
-    assert provider._quota_cooldown_seconds(RPD_429) is None
-    assert provider._quota_cooldown_seconds("429 quota exceeded retry in 12s") is None
+    # Explicit RPD is handled outside the cooldown helper.
+    assert provider._is_per_day_quota_error(RPD_429) is True
+
+
+def test_quota_cooldown_seconds_ambiguous_quota_is_transient(provider):
+    assert provider._quota_cooldown_seconds("429 quota exceeded retry in 12s") == pytest.approx(
+        12 + provider.RPM_COOLDOWN_BUFFER_SECONDS
+    )
 
 
 def test_is_invalid_key_error(provider):

--- a/tests/unit/test_new_integrations.py
+++ b/tests/unit/test_new_integrations.py
@@ -2738,9 +2738,10 @@ def test_google_genai_config_loads_env_style_api_keys_file(tmp_path):
 def test_google_genai_config_rejects_empty_api_key_file(tmp_path):
     key_file = tmp_path / "google_keys.txt"
     key_file.write_text("# still empty\n\n")
+    config_kwargs = {"name": "test", "type": "google-genai", "enabled": True, "api_keys_file": str(key_file)}
 
     with pytest.raises(ValueError, match="No valid API keys found"):
-        GoogleGenAIConfig(name="test", type="google-genai", enabled=True, api_keys_file=str(key_file))
+        GoogleGenAIConfig(**config_kwargs)
 
 
 def test_anthropic_config_loads_api_keys_file_once_during_init(tmp_path):
@@ -2778,15 +2779,16 @@ def test_anthropic_config_loads_env_style_api_keys_file(tmp_path):
 
 def test_anthropic_config_raises_when_api_keys_file_is_missing(tmp_path):
     missing_file = tmp_path / "missing.txt"
+    config_kwargs = {
+        "name": "test",
+        "type": "anthropic",
+        "enabled": True,
+        "url": "https://api.anthropic.com",
+        "api_keys_file": str(missing_file),
+    }
 
     with pytest.raises(ValueError, match="API key file not found"):
-        AnthropicConfig(
-            name="test",
-            type="anthropic",
-            enabled=True,
-            url="https://api.anthropic.com",
-            api_keys_file=str(missing_file),
-        )
+        AnthropicConfig(**config_kwargs)
 
 
 def test_anthropic_request_format_conversion():

--- a/tests/unit/test_new_integrations.py
+++ b/tests/unit/test_new_integrations.py
@@ -1052,6 +1052,59 @@ async def test_google_genai_get_api_key_stats_groups_used_and_unused_keys():
     assert used_entry["quota_exhausted"] is True
 
 
+def test_google_genai_log_quota_status_treats_estimate_overage_as_warning(caplog):
+    provider = _make_google_provider()
+    quota = QuotaRecord(
+        {
+            "api_key_hash": "abcdef1234567890",
+            "model_name": "gemini-3.1-flash-lite",
+            "requests_today": 43,
+            "tokens_today": 11,
+            "error_count": 0,
+            "last_reset_date": provider._get_pacific_date(),
+            "invalid_key": False,
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="smolrouter.google_genai_provider"):
+        provider._log_quota_status("used-key", "gemini-3.1-flash-lite", quota)
+
+    assert "DAILY LIMIT REACHED" not in caplog.text
+    assert "exceeded configured daily estimate after a successful request" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_google_genai_get_api_key_stats_does_not_mark_estimate_only_overage_as_exhausted():
+    provider = _make_google_provider(api_keys=["used-key"])
+    used_quota = QuotaRecord(
+        {
+            "api_key_hash": "abcdef1234567890",
+            "model_name": "gemini-3.1-flash-lite",
+            "requests_today": 43,
+            "tokens_today": 11,
+            "error_count": 0,
+            "last_reset_date": provider._get_pacific_date(),
+            "invalid_key": False,
+            "updated_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+
+    api_key_backend = SimpleNamespace(
+        get_provider_usage=AsyncMock(return_value=[used_quota]),
+        hash_api_key=lambda api_key: "abcdef1234567890",
+    )
+
+    with patch("smolrouter.google_genai_provider.ApiKeyQuota", api_key_backend):
+        stats = await provider.get_api_key_stats(include_unused_models=True)
+
+    used_entry = stats["abcdef12..."]["models"]["gemini-3.1-flash-lite"]
+    assert used_entry["quota_percentage"] == 215.0
+    assert used_entry["quota_exhausted"] is False
+    assert used_entry["daily_limit_estimate_exceeded"] is True
+    assert used_entry["status"] == "available"
+
+
 @pytest.mark.asyncio
 async def test_google_genai_probe_proxy_url_marks_invalid_and_successful_hosts():
     provider = _make_google_provider()

--- a/tests/unit/test_new_integrations.py
+++ b/tests/unit/test_new_integrations.py
@@ -1076,70 +1076,43 @@ async def test_google_genai_probe_proxy_url_marks_invalid_and_successful_hosts()
 
 @pytest.mark.asyncio
 async def test_google_genai_select_best_api_key_handles_exhaustion_and_fallback():
-    exhausted_provider = _make_google_provider(api_keys=["key-a", "key-b"], predictive_429_enabled=True)
-    exhausted_today = exhausted_provider._get_pacific_date()
-    exhausted_provider._get_quota_record = AsyncMock(
-        side_effect=[
-            QuotaRecord(
-                {
-                    "api_key_hash": "hash-a",
-                    "model_name": "gemini-2.0-flash",
-                    "requests_today": 0,
-                    "tokens_today": 0,
-                    "error_count": 0,
-                    "last_reset_date": exhausted_today,
-                    "quota_exhausted_at": datetime.now(timezone.utc),
-                    "invalid_key": False,
-                }
-            ),
-            QuotaRecord(
-                {
-                    "api_key_hash": "hash-b",
-                    "model_name": "gemini-2.0-flash",
-                    "requests_today": 0,
-                    "tokens_today": 0,
-                    "error_count": 21,
-                    "last_reset_date": exhausted_today,
-                    "invalid_key": False,
-                }
-            ),
-        ]
-    )
+    provider = _make_google_provider(api_keys=["key-a", "key-b"], predictive_429_enabled=False)
 
-    with pytest.raises(ResourceExhausted):
-        await exhausted_provider._select_best_api_key("gemini-2.0-flash")
+    with patch(
+        "smolrouter.google_genai_provider.ApiKeyQuota.select_google_api_key",
+        AsyncMock(
+            return_value={
+                "status": "none_available",
+                "selected_index": None,
+                "cooling_down_count": 0,
+                "exhausted_count": 2,
+                "retry_after_seconds": 123,
+            }
+        ),
+    ):
+        with pytest.raises(ResourceExhausted, match="Retry in 123 seconds"):
+            await provider._select_best_api_key("gemini-2.0-flash")
 
-    fallback_provider = _make_google_provider(api_keys=["key-a", "key-b"], predictive_429_enabled=False)
-    fallback_today = fallback_provider._get_pacific_date()
-    fallback_provider._get_quota_record = AsyncMock(
-        side_effect=[
-            QuotaRecord(
-                {
-                    "api_key_hash": "hash-a",
-                    "model_name": "gemini-2.0-flash",
-                    "requests_today": 0,
-                    "tokens_today": 0,
-                    "error_count": 0,
-                    "last_reset_date": fallback_today,
-                    "quota_exhausted_at": datetime.now(timezone.utc),
-                    "invalid_key": False,
-                }
-            ),
-            QuotaRecord(
-                {
-                    "api_key_hash": "hash-b",
-                    "model_name": "gemini-2.0-flash",
-                    "requests_today": 0,
-                    "tokens_today": 0,
-                    "error_count": 21,
-                    "last_reset_date": fallback_today,
-                    "invalid_key": False,
-                }
-            ),
-        ]
-    )
 
-    assert await fallback_provider._select_best_api_key("gemini-2.0-flash") == "key-a"
+@pytest.mark.asyncio
+async def test_google_genai_select_best_api_key_raises_hard_failure_when_all_keys_invalid():
+    provider = _make_google_provider(api_keys=["key-a", "key-b"], predictive_429_enabled=False)
+
+    with patch(
+        "smolrouter.google_genai_provider.ApiKeyQuota.select_google_api_key",
+        AsyncMock(
+            return_value={
+                "status": "all_invalid",
+                "selected_index": None,
+                "invalid_count": 2,
+                "cooling_down_count": 0,
+                "exhausted_count": 0,
+                "retry_after_seconds": 0,
+            }
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="No usable Google API keys available"):
+            await provider._select_best_api_key("gemini-2.0-flash")
 
 
 # Real per-minute (RPM) 429 body: quotaId says PerMinute and Google supplies a 21s retryDelay.
@@ -1197,65 +1170,61 @@ async def test_per_minute_429_sets_cooldown_not_all_day_exhaustion():
 
 
 @pytest.mark.asyncio
-async def test_select_best_api_key_skips_cooldown_and_prefers_soonest_recovery():
-    """Cooling-down keys are skipped; when all are cooling down, fall back to the
-    soonest-recovering one instead of always api_keys[0]."""
+async def test_select_best_api_key_skips_cooldown_and_raises_when_all_keys_are_cooling_down():
+    """Cooling-down keys are skipped; when all are cooling down, surface a transient quota error."""
     provider = _make_google_provider(api_keys=["key-1", "key-2"], predictive_429_enabled=False)
-    today = provider._get_pacific_date()
-    now = datetime.now(timezone.utc)
-
-    # key-1 cools down for ~5 min; key-2 cools down for ~20s (recovers soonest).
-    key1 = QuotaRecord(
-        {
-            "api_key_hash": "hash-1",
-            "model_name": "gemini-3.1-flash-lite",
-            "requests_today": 0,
-            "tokens_today": 0,
-            "error_count": 0,
-            "last_reset_date": today,
-            "invalid_key": False,
-            "quota_cooldown_until": now + timedelta(seconds=300),
-        }
-    )
-    key2 = QuotaRecord(
-        {
-            "api_key_hash": "hash-2",
-            "model_name": "gemini-3.1-flash-lite",
-            "requests_today": 0,
-            "tokens_today": 0,
-            "error_count": 0,
-            "last_reset_date": today,
-            "invalid_key": False,
-            "quota_cooldown_until": now + timedelta(seconds=20),
-        }
-    )
-    provider._get_quota_record = AsyncMock(side_effect=[key1, key2])
-
-    selected = await provider._select_best_api_key("gemini-3.1-flash-lite")
-    # NOT api_keys[0] (key-1) — the soonest-recovering key wins.
-    assert selected == "key-2"
+    with patch(
+        "smolrouter.google_genai_provider.ApiKeyQuota.select_google_api_key",
+        AsyncMock(
+            return_value={
+                "status": "none_available",
+                "selected_index": None,
+                "cooling_down_count": 2,
+                "exhausted_count": 0,
+                "retry_after_seconds": 19,
+            }
+        ),
+    ):
+        with pytest.raises(ResourceExhausted, match="Retry in 19 seconds"):
+            await provider._select_best_api_key("gemini-3.1-flash-lite")
 
 
 @pytest.mark.asyncio
 async def test_select_best_api_key_ignores_expired_cooldown():
     """A cooldown in the past must not exclude the key from selection."""
     provider = _make_google_provider(api_keys=["key-1"], predictive_429_enabled=False)
-    today = provider._get_pacific_date()
-    quota = QuotaRecord(
-        {
-            "api_key_hash": "hash-1",
-            "model_name": "gemini-3.1-flash-lite",
-            "requests_today": 3,
-            "tokens_today": 0,
-            "error_count": 0,
-            "last_reset_date": today,
-            "invalid_key": False,
-            "quota_cooldown_until": datetime.now(timezone.utc) - timedelta(seconds=5),
-        }
-    )
-    provider._get_quota_record = AsyncMock(return_value=quota)
+    with patch(
+        "smolrouter.google_genai_provider.ApiKeyQuota.select_google_api_key",
+        AsyncMock(
+            return_value={
+                "status": "ok",
+                "selected_index": 0,
+                "cooling_down_count": 0,
+                "exhausted_count": 0,
+                "retry_after_seconds": 0,
+            }
+        ),
+    ):
+        assert await provider._select_best_api_key("gemini-3.1-flash-lite") == "key-1"
 
-    assert await provider._select_best_api_key("gemini-3.1-flash-lite") == "key-1"
+
+@pytest.mark.asyncio
+async def test_select_best_api_key_maps_selected_index_to_api_key():
+    provider = _make_google_provider(api_keys=["key-1", "key-2"], predictive_429_enabled=False)
+
+    with patch(
+        "smolrouter.google_genai_provider.ApiKeyQuota.select_google_api_key",
+        AsyncMock(
+            return_value={
+                "status": "ok",
+                "selected_index": 1,
+                "cooling_down_count": 0,
+                "exhausted_count": 0,
+                "retry_after_seconds": 0,
+            }
+        ),
+    ):
+        assert await provider._select_best_api_key("gemini-2.5-flash-lite") == "key-2"
 
 
 def test_dummy_provider_discover_models_and_stats():

--- a/tests/unit/test_new_integrations.py
+++ b/tests/unit/test_new_integrations.py
@@ -894,6 +894,7 @@ async def test_google_genai_update_api_key_stats_covers_success_and_error_branch
     api_key_backend = SimpleNamespace(
         hash_api_key=lambda api_key: f"hash-{api_key}",
         mark_invalid_by_hash=AsyncMock(),
+        mark_quota_cooldown=AsyncMock(),
         mark_quota_exhausted=AsyncMock(),
         mark_error=AsyncMock(),
     )
@@ -911,6 +912,18 @@ async def test_google_genai_update_api_key_stats_covers_success_and_error_branch
         }
     )
     invalid_quota = QuotaRecord(
+        {
+            "api_key_hash": "hash-test-key",
+            "model_name": "gemini-2.0-flash",
+            "requests_today": 0,
+            "tokens_today": 0,
+            "error_count": 0,
+            "last_reset_date": provider._get_pacific_date(),
+            "invalid_key": False,
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )
+    cooldown_quota = QuotaRecord(
         {
             "api_key_hash": "hash-test-key",
             "model_name": "gemini-2.0-flash",
@@ -961,7 +974,7 @@ async def test_google_genai_update_api_key_stats_covers_success_and_error_branch
     )
 
     provider._get_quota_record = AsyncMock(
-        side_effect=[success_quota, invalid_quota, quota_exhausted, regular_quota, entitlement_quota]
+        side_effect=[success_quota, invalid_quota, cooldown_quota, quota_exhausted, regular_quota, entitlement_quota]
     )
 
     with patch("smolrouter.redis_backend.RedisApiKeyQuota.increment_usage", AsyncMock(return_value=None)), patch(
@@ -988,6 +1001,19 @@ async def test_google_genai_update_api_key_stats_covers_success_and_error_branch
             "gemini-2.0-flash",
             success=False,
             error="429 quota exceeded retry in 12s",
+            status_code=429,
+        )
+        assert cooldown_quota.quota_exhausted_at is None
+        assert cooldown_quota.quota_cooldown_until is not None
+        assert api_key_backend.mark_quota_cooldown.await_count == 1
+        assert api_key_backend.mark_quota_exhausted.await_count == 0
+
+        provider.config.api_keys = ["test-key"]
+        await provider._update_api_key_stats(
+            "test-key",
+            "gemini-2.0-flash",
+            success=False,
+            error="429 quota exceeded requests per day",
             status_code=429,
         )
         assert quota_exhausted.error_count == 1

--- a/tests/unit/test_redis_backend.py
+++ b/tests/unit/test_redis_backend.py
@@ -522,6 +522,10 @@ async def test_api_key_quota_round_trip_and_usage_markers(monkeypatch):
     assert provider_a_usage[0].last_error == "daily limit"
     assert provider_a_usage[0].invalid_key is True
     assert provider_a_usage[0].quota_exhausted_at is not None
+    assert await redis_client.sismember(
+        RedisApiKeyQuota.google_invalid_keys_key("provider-a"),
+        RedisApiKeyQuota.hash_api_key("sk-test"),
+    )
     assert len(provider_b_usage) == 1
     assert provider_b_usage[0].invalid_key is False
 
@@ -532,6 +536,7 @@ async def test_mark_quota_cooldown_round_trips_and_clears_on_daily_reset(monkeyp
     monkeypatch.setattr(redis_backend_module, "_circuit_breaker", redis_backend_module.RedisCircuitBreaker())
     monkeypatch.setattr(RedisApiKeyQuota, "_script_initialized", False)
     monkeypatch.setattr(RedisApiKeyQuota, "_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_google_selector_script_sha", None)
     monkeypatch.setattr(RedisApiKeyQuota, "_lua_disabled", True)
 
     await RedisApiKeyQuota.get_or_create_quota("sk-cool", "provider-c", "gemini-3.1-flash-lite")
@@ -556,3 +561,179 @@ async def test_mark_quota_cooldown_round_trips_and_clears_on_daily_reset(monkeyp
 
     usage_after = await RedisApiKeyQuota.get_provider_usage("provider-c")
     assert usage_after[0].quota_cooldown_until is None
+
+
+@pytest.mark.asyncio
+async def test_select_google_api_key_uses_serial_rotary_order_per_model(monkeypatch):
+    await redis_client.flushall()
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_initialized", False)
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_google_selector_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_lua_disabled", True)
+
+    first = await RedisApiKeyQuota.select_google_api_key(
+        provider_id="provider-rr",
+        model_name="gemini-2.5-flash-lite",
+        api_keys=["key-1", "key-2"],
+        model_limit=1000,
+    )
+    second = await RedisApiKeyQuota.select_google_api_key(
+        provider_id="provider-rr",
+        model_name="gemini-2.5-flash-lite",
+        api_keys=["key-1", "key-2"],
+        model_limit=1000,
+    )
+    third = await RedisApiKeyQuota.select_google_api_key(
+        provider_id="provider-rr",
+        model_name="gemini-2.5-flash-lite",
+        api_keys=["key-1", "key-2"],
+        model_limit=1000,
+    )
+    other_model = await RedisApiKeyQuota.select_google_api_key(
+        provider_id="provider-rr",
+        model_name="gemini-2.0-flash",
+        api_keys=["key-1", "key-2"],
+        model_limit=1000,
+    )
+
+    assert first["status"] == "ok"
+    assert first["selected_index"] == 0
+    assert second["selected_index"] == 1
+    assert third["selected_index"] == 0
+    assert other_model["selected_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_select_google_api_key_skips_cooling_and_observed_exhausted_keys(monkeypatch):
+    await redis_client.flushall()
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_initialized", False)
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_google_selector_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_lua_disabled", True)
+
+    model_name = "gemini-2.5-flash-lite"
+    provider_id = "provider-skip"
+    await RedisApiKeyQuota.get_or_create_quota("key-1", provider_id, model_name)
+    await RedisApiKeyQuota.get_or_create_quota("key-2", provider_id, model_name)
+
+    cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=30)
+    await RedisApiKeyQuota.mark_quota_cooldown("key-1", provider_id, model_name, cooldown_until, "per-minute limit")
+
+    exhausted_key_hash = RedisApiKeyQuota.hash_api_key("key-2")
+    exhausted_quota_key = f"quota:{provider_id}:{exhausted_key_hash}:{model_name}"
+    await redis_client.hset(
+        exhausted_quota_key,
+        mapping={
+            "quota_exhausted_at": datetime.now(timezone.utc).isoformat(),
+            "last_reset": redis_backend_module._current_pacific_date(),
+            "last_reset_date": redis_backend_module._current_pacific_date(),
+        },
+    )
+
+    selection = await RedisApiKeyQuota.select_google_api_key(
+        provider_id=provider_id,
+        model_name=model_name,
+        api_keys=["key-1", "key-2", "key-3"],
+        model_limit=1000,
+    )
+
+    assert selection["status"] == "ok"
+    assert selection["selected_index"] == 2
+
+
+@pytest.mark.asyncio
+async def test_select_google_api_key_does_not_preemptively_exclude_by_request_count(monkeypatch):
+    await redis_client.flushall()
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_initialized", False)
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_google_selector_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_lua_disabled", True)
+
+    provider_id = "provider-count"
+    model_name = "gemini-2.5-flash-lite"
+    await RedisApiKeyQuota.get_or_create_quota("key-1", provider_id, model_name)
+
+    quota_key = f"quota:{provider_id}:{RedisApiKeyQuota.hash_api_key('key-1')}:{model_name}"
+    await redis_client.hset(
+        quota_key,
+        mapping={
+            "requests_today": "1000",
+            "last_reset": redis_backend_module._current_pacific_date(),
+            "last_reset_date": redis_backend_module._current_pacific_date(),
+        },
+    )
+
+    selection = await RedisApiKeyQuota.select_google_api_key(
+        provider_id=provider_id,
+        model_name=model_name,
+        api_keys=["key-1"],
+        model_limit=1000,
+    )
+
+    assert selection["status"] == "ok"
+    assert selection["selected_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_select_google_api_key_returns_retry_when_all_keys_cooling_down(monkeypatch):
+    await redis_client.flushall()
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_initialized", False)
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_google_selector_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_lua_disabled", True)
+
+    provider_id = "provider-cool"
+    model_name = "gemini-3.1-flash-lite"
+    await RedisApiKeyQuota.get_or_create_quota("key-1", provider_id, model_name)
+    await RedisApiKeyQuota.get_or_create_quota("key-2", provider_id, model_name)
+
+    await RedisApiKeyQuota.mark_quota_cooldown(
+        "key-1",
+        provider_id,
+        model_name,
+        datetime.now(timezone.utc) + timedelta(seconds=60),
+        "per-minute limit",
+    )
+    await RedisApiKeyQuota.mark_quota_cooldown(
+        "key-2",
+        provider_id,
+        model_name,
+        datetime.now(timezone.utc) + timedelta(seconds=20),
+        "per-minute limit",
+    )
+
+    selection = await RedisApiKeyQuota.select_google_api_key(
+        provider_id=provider_id,
+        model_name=model_name,
+        api_keys=["key-1", "key-2"],
+        model_limit=1000,
+    )
+
+    assert selection["status"] == "none_available"
+    assert selection["cooling_down_count"] == 2
+    assert selection["exhausted_count"] == 0
+    assert 0 < selection["retry_after_seconds"] <= 25
+
+
+@pytest.mark.asyncio
+async def test_select_google_api_key_skips_provider_invalid_key_even_without_model_quota(monkeypatch):
+    await redis_client.flushall()
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_initialized", False)
+    monkeypatch.setattr(RedisApiKeyQuota, "_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_google_selector_script_sha", None)
+    monkeypatch.setattr(RedisApiKeyQuota, "_lua_disabled", True)
+
+    provider_id = "provider-invalid"
+    invalid_hash = RedisApiKeyQuota.hash_api_key("key-1")
+    await redis_client.sadd(RedisApiKeyQuota.google_invalid_keys_key(provider_id), invalid_hash)
+
+    selection = await RedisApiKeyQuota.select_google_api_key(
+        provider_id=provider_id,
+        model_name="gemini-2.5-flash-lite",
+        api_keys=["key-1", "key-2"],
+        model_limit=1000,
+    )
+
+    assert selection["status"] == "ok"
+    assert selection["selected_index"] == 1
+    assert selection["invalid_count"] == 1

--- a/tests/unit/test_secret_store.py
+++ b/tests/unit/test_secret_store.py
@@ -11,6 +11,7 @@ from smolrouter.secret_store import (
     reload_secrets,
     redact_secret,
     resolve_config_file,
+    secret_suffix,
     secrets_search_paths,
 )
 
@@ -267,3 +268,11 @@ def test_redact_secret_no_full_key_leaked_in_google_provider_init_logs(caplog):
         GoogleGenAIProvider(config)
 
     assert full_key not in caplog.text
+
+
+def test_redact_secret_uses_suffix_for_distinguishing_google_keys():
+    full_key = "AIzaSyExampleKey1234567890abcdefgh"
+
+    assert secret_suffix(full_key) == "abcdefgh"
+    assert redact_secret(full_key) == "…abcdefgh"
+    assert "AIzaS" not in redact_secret(full_key)


### PR DESCRIPTION
## What changed

This switches Google request-time API key selection over to Redis-backed serial rotary selection per provider/model.

- request-path key choice is now atomic in Redis rather than Python process memory
- same-request auto retry is removed
- request-time exclusion is intentionally narrow: invalid keys, active RPM cooldowns, and observed same-day exhaustion
- durable provider-level invalid-key exclusion is added so invalid keys do not re-enter rotation on other models/workers/restarts
- `no_keys` / `all_invalid` are surfaced as hard failures rather than retryable quota exhaustion

## Why

The main problem was that request-time selection and exclusion behavior could pin traffic onto the wrong key or depend too heavily on dead-reckoned quota state.

With serial rotary selection, the barrel itself is the primary balancing mechanism. The request path should therefore optimize for service availability and atomic coordination, not aggressive predictive exclusion.

## Root cause

Google key selection was previously handled in Python with local process state and broader predictive logic. Under load and concurrency, that left room for stale or non-atomic behavior.

## Impact

- request traffic should distribute predictably in fixed serial order across eligible keys
- RPM 429 handling remains short-lived and should not footgun a key for the rest of the day
- dead-reckoned request counts are no longer used to rank or preemptively bench keys on the request path

## Validation

- `uv run pytest -q tests/unit/test_redis_backend.py tests/unit/test_new_integrations.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rotary Google API-key selection flow with structured cooldown/exhaustion status, retry timing (including next Pacific midnight), and a Redis-script fallback.
  * Improved Google request/image context initialization for more deterministic validation and key suffixing.

* **Bug Fixes**
  * Refined quota exhaustion vs estimate-based overage handling: only confirmed exhaustion triggers “daily limit reached”; estimate-only overages now warn.
  * Strengthened invalid-key tracking/exclusion for Google keys.
  * Updated API-key suffix derivation to use a stable suffix for correlation.

* **Tests**
  * Expanded Redis and unit coverage for Google key selection, cooldown/retry behavior, quota logging, key-stats semantics, and secret redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->